### PR TITLE
 Feat: Add opcode PUSH0 and PUSHn

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             name: "Interpreter",
             dependencies: ["PrimitiveTypes"],
             swiftSettings: [
-                .define("TRACING"),
+                .define("DISABLE_TRACING"),
             ]),
         .target(
             name: "PrimitiveTypes"),
@@ -33,7 +33,7 @@ let package = Package(
             name: "InterpreterTests",
             dependencies: ["Interpreter", "PrimitiveTypes", "Quick", "Nimble"],
             swiftSettings: [
-                .define("TRACING"),
+                .define("DISABLE_TRACING"),
             ]),
         .testTarget(
             name: "PrimitiveTypesTests",

--- a/Sources/Interpreter/Instructions/Stack.swift
+++ b/Sources/Interpreter/Instructions/Stack.swift
@@ -45,9 +45,9 @@ enum StackInstructions {
             let slice = m.code[(m.pc + 1) ..< end]
             var val = [UInt8](repeating: 0, count: 32)
             val.replaceSubrange(32 - n ..< 32 - n + slice.count, with: slice)
-            val.replaceSubrange(32 - n ..< 32 - n + slice.count, with: Array(slice))
 
             let newValue = U256.fromBigEndian(from: val)
+            m.machineStatus = Machine.MachineStatus.AddPC(n + 1)
             try m.stack.push(value: newValue).get()
         } catch {
             m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))

--- a/Sources/Interpreter/Instructions/Stack.swift
+++ b/Sources/Interpreter/Instructions/Stack.swift
@@ -14,4 +14,43 @@ enum StackInstructions {
             m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
         }
     }
+
+    /// ## Description
+    /// Pushes the constant value 0 onto the stack.
+    ///
+    /// ## EIP
+    /// EIP-3855: PUSH0 instruction
+    /// https://eips.ethereum.org/EIPS/eip-3855
+    static func push0(machine m: inout Machine) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.BASE) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            try m.stack.push(value: U256.ZERO).get()
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
+
+    static func push(machine m: inout Machine, n: Int) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            let end = min(m.pc + 1 + n, m.codeSize)
+            let slice = m.code[(m.pc + 1) ..< end]
+            var val = [UInt8](repeating: 0, count: 32)
+            val.replaceSubrange(32 - n ..< 32 - n + slice.count, with: slice)
+            val.replaceSubrange(32 - n ..< 32 - n + slice.count, with: Array(slice))
+
+            let newValue = U256.fromBigEndian(from: val)
+            try m.stack.push(value: newValue).get()
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
 }

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -11,9 +11,9 @@ public protocol InterpreterHandler {
 /// Machine represents EVM core execution layer
 public struct Machine {
     /// Program data
-    private let data: [UInt8]
+    let data: [UInt8]
     /// Program code.
-    private let code: [UInt8]
+    let code: [UInt8]
     /// Program counter.
     private(set) var pc: Int = 0
     /// Return value.
@@ -114,6 +114,39 @@ public struct Machine {
         table[Opcode.CODESIZE.index] = SystemInstructions.codeSize
         table[Opcode.PC.index] = SystemInstructions.pc
         table[Opcode.POP.index] = StackInstructions.pop
+        table[Opcode.PUSH0.index] = StackInstructions.push0
+        table[Opcode.PUSH1.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 1) }
+        table[Opcode.PUSH2.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 2) }
+        table[Opcode.PUSH3.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 3) }
+        table[Opcode.PUSH4.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 4) }
+        table[Opcode.PUSH5.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 5) }
+        table[Opcode.PUSH6.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 6) }
+        table[Opcode.PUSH7.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 7) }
+        table[Opcode.PUSH8.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 8) }
+        table[Opcode.PUSH9.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 9) }
+        table[Opcode.PUSH10.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 10) }
+        table[Opcode.PUSH11.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 11) }
+        table[Opcode.PUSH12.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 12) }
+        table[Opcode.PUSH13.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 13) }
+        table[Opcode.PUSH14.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 14) }
+        table[Opcode.PUSH15.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 15) }
+        table[Opcode.PUSH16.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 16) }
+        table[Opcode.PUSH17.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 17) }
+        table[Opcode.PUSH18.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 18) }
+        table[Opcode.PUSH19.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 19) }
+        table[Opcode.PUSH20.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 20) }
+        table[Opcode.PUSH21.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 21) }
+        table[Opcode.PUSH22.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 22) }
+        table[Opcode.PUSH23.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 23) }
+        table[Opcode.PUSH24.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 24) }
+        table[Opcode.PUSH25.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 25) }
+        table[Opcode.PUSH26.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 26) }
+        table[Opcode.PUSH27.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 27) }
+        table[Opcode.PUSH28.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 28) }
+        table[Opcode.PUSH29.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 29) }
+        table[Opcode.PUSH30.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 30) }
+        table[Opcode.PUSH31.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 31) }
+        table[Opcode.PUSH32.index] = { (_ m: inout Self) in StackInstructions.push(machine: &m, n: 32) }
 
         return table
     }()

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -43,7 +43,9 @@ public struct Machine {
     public enum MachineStatus: Equatable {
         case NotStarted
         case Continue
-        case Jump(Int)
+        case AddPC(Int)
+        // TODO: add for JUMP instructions
+        // case Jump(Int)
         case Trap(Opcode)
         case Exit(ExitReason)
     }
@@ -156,7 +158,9 @@ public struct Machine {
         self.code = code
         self.handler = handler
         self.gas = Gas(limit: gasLimit)
+        #if TRACING
         self.trace = Trace()
+        #endif
     }
 
     /// Provide one step for `Machine` execution.
@@ -185,12 +189,23 @@ public struct Machine {
         // NOTE: It can change `MachineStatus` or `PC`
         evalFunc(&self)
 
+        // Change `PC` for the next step
+        switch self.machineStatus {
+        case .AddPC(let add):
+            self.pc += add
+            self.machineStatus = .Continue
+
+        // TODO: Add for JUMP instr
+        // case .Jump(let jumpPC):
+        //    self.pc = jumpPC
+        //    self.machineStatus = .Continue
+        default:
+            self.pc += 1
+        }
+
         #if TRACING
         self.trace.afterEval(self).complete()
         #endif
-
-        // Increment `PC` for the next step
-        self.pc += 1
     }
 
     /// Evaluation loop for `Machine` code.

--- a/Tests/InterpreterTests/InstructionsTests/Stack/PopTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Stack/PopTests.swift
@@ -14,7 +14,6 @@ final class InstructionPopSpec: QuickSpec {
 
                 let _ = m.stack.push(value: U256(from: 5))
                 m.evalLoop()
-                m.trace.printOutput()
 
                 expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
                 expect(m.stack.length).to(equal(0))

--- a/Tests/InterpreterTests/InstructionsTests/Stack/Push0Tests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Stack/Push0Tests.swift
@@ -1,0 +1,50 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionPush0Spec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.PUSH0, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction PUSH0") {
+            it("PUSH 0") {
+                var m = TestMachine.machine(opcode: Opcode.PUSH0, gasLimit: 10)
+
+                m.evalLoop()
+                let result = m.stack.pop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                expect(result).to(beSuccess { value in
+                    expect(value).to(equal(U256.ZERO))
+                })
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(8))
+            }
+
+            it("with OutOfGas result") {
+                var m = Self.machineLowGas
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(1))
+            }
+
+            it("check stack overflow") {
+                var m = TestMachine.machine(opcode: Opcode.PUSH0, gasLimit: 10)
+                for _ in 0 ..< m.stack.limit {
+                    let _ = m.stack.push(value: U256(from: 5))
+                }
+
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackOverflow))))
+                expect(m.stack.length).to(equal(m.stack.limit))
+                expect(m.gas.remaining).to(equal(8))
+            }
+        }
+    }
+}
+

--- a/Tests/InterpreterTests/InstructionsTests/Stack/PushTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Stack/PushTests.swift
@@ -1,0 +1,88 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionPushSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.PUSH1, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction PUSH") {
+            it("PUSH n with complete code size") {
+                for n in 1 ... UInt8(32) {
+                    var code: [UInt8] = [Opcode.PUSH1.rawValue + n - 1]
+                    let number: [UInt8] = Array(1 ... n)
+                    code.append(contentsOf: number)
+
+                    var m = TestMachine.machine(rawCode: code, gasLimit: 10)
+
+                    m.evalLoop()
+                    let result = m.stack.pop()
+
+                    expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                    expect(result).to(beSuccess { value in
+                        expect(value).to(equal(U256.fromBigEndian(from: number)))
+                    })
+                    expect(m.pc).to(equal(1 + Int(n)))
+                    expect(m.stack.length).to(equal(0))
+                    expect(m.gas.remaining).to(equal(7))
+                }
+            }
+
+            it("PUSH n with incomplete code size") {
+                for n in 1 ... UInt8(32) {
+                    var code: [UInt8] = [Opcode.PUSH1.rawValue + n - 1]
+                    // Values only in range: 1..10
+                    if n <= 10 {
+                        code.append(contentsOf: Array(1 ... n))
+                    } else {
+                        code.append(contentsOf: Array(1 ... 10))
+                    }
+
+                    /// Generate incomplete array with zero values after index 10
+                    let expectedNumber: [UInt8] = if n <= 10 {
+                        Array(1 ... n)
+                    } else {
+                        (0 ..< n).map { index in index < 10 ? UInt8(index + 1) : 0 }
+                    }
+
+                    var m = TestMachine.machine(rawCode: code, gasLimit: 10)
+
+                    m.evalLoop()
+                    let result = m.stack.pop()
+
+                    expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                    expect(result).to(beSuccess { value in
+                        expect(value).to(equal(U256.fromBigEndian(from: expectedNumber)))
+                    })
+                    expect(m.pc).to(equal(1 + Int(n)))
+                    expect(m.stack.length).to(equal(0))
+                    expect(m.gas.remaining).to(equal(7))
+                }
+            }
+
+            it("with OutOfGas result") {
+                var m = Self.machineLowGas
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(1))
+            }
+        }
+
+        it("check stack overflow") {
+            var m = TestMachine.machine(opcode: Opcode.PUSH1, gasLimit: 10)
+            for _ in 0 ..< m.stack.limit {
+                let _ = m.stack.push(value: U256(from: 5))
+            }
+
+            m.evalLoop()
+            expect(m.machineStatus).to(equal(.Exit(.Error(.StackOverflow))))
+            expect(m.stack.length).to(equal(m.stack.limit))
+            expect(m.gas.remaining).to(equal(7))
+        }
+    }
+}

--- a/Tests/InterpreterTests/MachineTests.swift
+++ b/Tests/InterpreterTests/MachineTests.swift
@@ -16,8 +16,13 @@ enum TestMachine {
         Machine(data: [], code: [opcode.rawValue], gasLimit: gasLimit, handler: TestHandler())
     }
 
-    /// Init Machine with predefined code with `Opcode` type
+    /// Init Machine with predefined code with array `Opcode` type
     static func machine(opcodes code: [Opcode], gasLimit: UInt64) -> Machine {
         Machine(data: [], code: code.map(\.rawValue), gasLimit: gasLimit, handler: TestHandler())
+    }
+
+    /// Init Machine with predefined code with raw data
+    static func machine(rawCode code: [UInt8], gasLimit: UInt64) -> Machine {
+        Machine(data: [], code: code, gasLimit: gasLimit, handler: TestHandler())
     }
 }


### PR DESCRIPTION
## Description

🚀 Added new EVM instructions.

➡️ Added opcode `PUSH0` and `PUSH1 .. PUSH32` instructions execution.
➡️ Added tests for opcodes and instructions.
➡️ Change `Machine` type visibility for some fields.
➡️ Added `MachineStatus.AddPC` for manipulations with `PC` for `PUSH` instrucitons.
➡️ Disable temporarily `TRACING` feature for tests
