### PR TITLE
 Feat: Add opcodes DUP1..DUP16

### DIFF
--- a/Sources/Interpreter/Instructions/Arithmetic.swift
+++ b/Sources/Interpreter/Instructions/Arithmetic.swift
@@ -4,12 +4,12 @@ import PrimitiveTypes
 enum ArithmeticInstructions {
     static func add(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let (newValue, _) = op1.overflowAdd(op2)
             try m.stack.push(value: newValue).get()
@@ -20,12 +20,12 @@ enum ArithmeticInstructions {
 
     static func sub(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let (newValue, _) = op1.overflowSub(op2)
             try m.stack.push(value: newValue).get()
@@ -36,12 +36,12 @@ enum ArithmeticInstructions {
 
     static func mul(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op1.mul(op2)
             try m.stack.push(value: newValue).get()
@@ -52,12 +52,12 @@ enum ArithmeticInstructions {
 
     static func div(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op2.isZero ? op2 : op1 / op2
             try m.stack.push(value: newValue).get()
@@ -68,12 +68,12 @@ enum ArithmeticInstructions {
 
     static func rem(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op2.isZero ? op2 : op1 % op2
             try m.stack.push(value: newValue).get()
@@ -84,12 +84,12 @@ enum ArithmeticInstructions {
 
     static func sdiv(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let iOp1 = I256.fromU256(op1)
             let iOp2 = I256.fromU256(op2)
@@ -102,12 +102,12 @@ enum ArithmeticInstructions {
 
     static func smod(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let iOp1 = I256.fromU256(op1)
             let iOp2 = I256.fromU256(op2)
@@ -120,13 +120,13 @@ enum ArithmeticInstructions {
 
     static func addMod(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
-            let op3 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.MID) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
+            let op3 = try m.stack.pop().get()
 
             let op1u512 = U512(from: op1)
             let op2u512 = U512(from: op2)
@@ -148,13 +148,13 @@ enum ArithmeticInstructions {
 
     static func mulMod(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
-            let op3 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.MID) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
+            let op3 = try m.stack.pop().get()
 
             let op1u512 = U512(from: op1)
             let op2u512 = U512(from: op2)
@@ -218,12 +218,12 @@ enum ArithmeticInstructions {
     /// bits from `b`; this is equal to `y & mask` where `&` is bitwise `AND`.
     static func signextend(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.LOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             var newValue = op2
             if op1 < U256(from: 32) {

--- a/Sources/Interpreter/Instructions/Bitwise.swift
+++ b/Sources/Interpreter/Instructions/Bitwise.swift
@@ -4,12 +4,13 @@ import PrimitiveTypes
 enum BItwiseInstructions {
     static func lt(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue: UInt64 = (op1 < op2) ? 1 : 0
             try m.stack.push(value: U256(from: newValue)).get()
@@ -20,12 +21,13 @@ enum BItwiseInstructions {
 
     static func gt(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue: UInt64 = (op1 > op2) ? 1 : 0
             try m.stack.push(value: U256(from: newValue)).get()
@@ -36,12 +38,13 @@ enum BItwiseInstructions {
 
     static func slt(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let iOp1 = I256.fromU256(op1)
             let iOp2 = I256.fromU256(op2)
@@ -55,12 +58,14 @@ enum BItwiseInstructions {
 
     static func sgt(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
+
             let iOp1 = I256.fromU256(op1)
             let iOp2 = I256.fromU256(op2)
 
@@ -73,12 +78,13 @@ enum BItwiseInstructions {
 
     static func eq(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue: UInt64 = (op1 == op2) ? 1 : 0
             try m.stack.push(value: U256(from: newValue)).get()
@@ -89,11 +95,12 @@ enum BItwiseInstructions {
 
     static func isZero(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
 
             let newValue: UInt64 = (op1.isZero) ? 1 : 0
             try m.stack.push(value: U256(from: newValue)).get()
@@ -104,12 +111,13 @@ enum BItwiseInstructions {
 
     static func and(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op1 & op2
             try m.stack.push(value: newValue).get()
@@ -120,12 +128,13 @@ enum BItwiseInstructions {
 
     static func or(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op1 | op2
             try m.stack.push(value: newValue).get()
@@ -136,12 +145,13 @@ enum BItwiseInstructions {
 
     static func xor(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             let newValue = op1 ^ op2
             try m.stack.push(value: newValue).get()
@@ -152,11 +162,12 @@ enum BItwiseInstructions {
 
     static func not(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
 
             let newValue = ~op1
             try m.stack.push(value: newValue).get()
@@ -167,12 +178,13 @@ enum BItwiseInstructions {
 
     static func byte(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             var newValue = U256.ZERO
             if op1 < U256(from: 32) {
@@ -192,12 +204,13 @@ enum BItwiseInstructions {
 
     static func shl(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             var newValue = U256.ZERO
             if !op2.isZero, op1 < U256(from: 256) {
@@ -213,12 +226,12 @@ enum BItwiseInstructions {
 
     static func shr(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
 
             var newValue = U256.ZERO
             if !op2.isZero, op1 < U256(from: 256) {
@@ -234,12 +247,13 @@ enum BItwiseInstructions {
 
     static func sar(machine m: inout Machine) {
         do {
-            let op1 = try m.stack.pop().get()
-            let op2 = try m.stack.pop().get()
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
+            let op1 = try m.stack.pop().get()
+            let op2 = try m.stack.pop().get()
+
             let iOp2 = I256.fromU256(op2)
 
             var newValue = U256.ZERO

--- a/Sources/Interpreter/Instructions/Stack.swift
+++ b/Sources/Interpreter/Instructions/Stack.swift
@@ -56,16 +56,30 @@ enum StackInstructions {
 
     static func swap(machine m: inout Machine, n: Int) {
         do {
-            let val1 = try m.stack.peek(indexFromTop: 0).get()
-            let val2 = try m.stack.peek(indexFromTop: n).get()
-
             if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
                 m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
                 return
             }
 
+            let val1 = try m.stack.peek(indexFromTop: 0).get()
+            let val2 = try m.stack.peek(indexFromTop: n).get()
+
             try m.stack.set(indexFromTop: n, value: val1).get()
             try m.stack.set(indexFromTop: 0, value: val2).get()
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
+
+    static func dup(machine m: inout Machine, n: Int) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.VERYLOW) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            let dupVal = try m.stack.peek(indexFromTop: n - 1).get()
+            try m.stack.push(value: dupVal).get()
         } catch {
             m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
         }

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -168,6 +168,22 @@ public struct Machine {
         table[Opcode.SWAP14.index] = { (_ m: inout Self) in StackInstructions.swap(machine: &m, n: 14) }
         table[Opcode.SWAP15.index] = { (_ m: inout Self) in StackInstructions.swap(machine: &m, n: 15) }
         table[Opcode.SWAP16.index] = { (_ m: inout Self) in StackInstructions.swap(machine: &m, n: 16) }
+        table[Opcode.DUP1.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 1) }
+        table[Opcode.DUP2.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 2) }
+        table[Opcode.DUP3.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 3) }
+        table[Opcode.DUP4.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 4) }
+        table[Opcode.DUP5.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 5) }
+        table[Opcode.DUP6.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 6) }
+        table[Opcode.DUP7.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 7) }
+        table[Opcode.DUP8.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 8) }
+        table[Opcode.DUP9.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 9) }
+        table[Opcode.DUP10.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 10) }
+        table[Opcode.DUP11.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 11) }
+        table[Opcode.DUP12.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 12) }
+        table[Opcode.DUP13.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 13) }
+        table[Opcode.DUP14.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 14) }
+        table[Opcode.DUP15.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 15) }
+        table[Opcode.DUP16.index] = { (_ m: inout Self) in StackInstructions.dup(machine: &m, n: 16) }
 
         return table
     }()

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/AddModTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/AddModTests.swift
@@ -37,7 +37,7 @@ final class InstructionAddModSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(2))
             }
 
             it("(a + b) % 0") {
@@ -66,7 +66,7 @@ final class InstructionAddModSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(3))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/AddTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/AddTests.swift
@@ -35,7 +35,7 @@ final class InstructionAddSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("max values") {
@@ -62,7 +62,7 @@ final class InstructionAddSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/DivTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/DivTests.swift
@@ -35,7 +35,7 @@ final class InstructionDivSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("max values 1") {
@@ -94,7 +94,7 @@ final class InstructionDivSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/ModTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/ModTests.swift
@@ -35,7 +35,7 @@ final class InstructionModSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("max values 1") {
@@ -94,7 +94,7 @@ final class InstructionModSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/MulModTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/MulModTests.swift
@@ -37,7 +37,7 @@ final class InstructionMulModSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(2))
             }
 
             it("(a * b) % 0") {
@@ -66,7 +66,7 @@ final class InstructionMulModSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(3))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/MulTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/MulTests.swift
@@ -36,7 +36,7 @@ final class InstructionMulSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("max values") {
@@ -63,7 +63,7 @@ final class InstructionMulSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/SDivTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/SDivTests.swift
@@ -67,7 +67,7 @@ final class InstructionSDivSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("max values 1") {
@@ -110,7 +110,7 @@ final class InstructionSDivSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/SModTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/SModTests.swift
@@ -67,7 +67,7 @@ final class InstructionSModSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("max values 1") {
@@ -110,7 +110,7 @@ final class InstructionSModSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/SignextendTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/SignextendTests.swift
@@ -104,7 +104,7 @@ final class InstructionSignextendSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(5))
             }
 
             it("(a exp 0)") {
@@ -131,7 +131,7 @@ final class InstructionSignextendSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Arithmetic/SubTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Arithmetic/SubTests.swift
@@ -51,7 +51,7 @@ final class InstructionSubSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("max values") {
@@ -78,7 +78,7 @@ final class InstructionSubSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/AndTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/AndTests.swift
@@ -35,7 +35,7 @@ final class InstructionAndSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -46,7 +46,7 @@ final class InstructionAndSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/ByteTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/ByteTests.swift
@@ -56,7 +56,7 @@ final class InstructionByteSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -67,7 +67,7 @@ final class InstructionByteSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/EqTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/EqTests.swift
@@ -51,7 +51,7 @@ final class InstructionEqSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -62,7 +62,7 @@ final class InstructionEqSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/GtTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/GtTests.swift
@@ -67,7 +67,7 @@ final class InstructionGtSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -78,7 +78,7 @@ final class InstructionGtSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/IsZeroTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/IsZeroTests.swift
@@ -48,7 +48,7 @@ final class InstructionIsZeroSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(1))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/LtTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/LtTests.swift
@@ -67,7 +67,7 @@ final class InstructionLtSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -78,7 +78,7 @@ final class InstructionLtSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/NotTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/NotTests.swift
@@ -33,7 +33,7 @@ final class InstructionNotSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(1))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/OrTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/OrTests.swift
@@ -35,7 +35,7 @@ final class InstructionOrSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -46,7 +46,7 @@ final class InstructionOrSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/SarTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/SarTests.swift
@@ -103,7 +103,7 @@ final class InstructionSarSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -114,7 +114,7 @@ final class InstructionSarSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/SgtTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/SgtTests.swift
@@ -115,7 +115,7 @@ final class InstructionSgtSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -126,7 +126,7 @@ final class InstructionSgtSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/ShlTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/ShlTests.swift
@@ -70,7 +70,7 @@ final class InstructionShlSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -81,7 +81,7 @@ final class InstructionShlSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/ShrTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/ShrTests.swift
@@ -70,7 +70,7 @@ final class InstructionShrSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -81,7 +81,7 @@ final class InstructionShrSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/SltTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/SltTests.swift
@@ -115,7 +115,7 @@ final class InstructionSltSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -126,7 +126,7 @@ final class InstructionSltSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Bitwise/XorTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Bitwise/XorTests.swift
@@ -35,7 +35,7 @@ final class InstructionXorSpec: QuickSpec {
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(0))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
 
             it("with OutOfGas result") {
@@ -46,7 +46,7 @@ final class InstructionXorSpec: QuickSpec {
                 m.evalLoop()
 
                 expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
-                expect(m.stack.length).to(equal(0))
+                expect(m.stack.length).to(equal(2))
                 expect(m.gas.remaining).to(equal(2))
             }
 

--- a/Tests/InterpreterTests/InstructionsTests/Stack/DupTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Stack/DupTests.swift
@@ -1,0 +1,88 @@
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionDupSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.DUP1, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction DUP") {
+            it("correct dup for DUP1..DUP16") {
+                for n in 0 ... UInt8(15) {
+                    var m = TestMachine.machine(rawCode: [Opcode.DUP1.rawValue + n], gasLimit: 10)
+
+                    for i in (1 ... UInt64(n + 1)).reversed() {
+                        let _ = m.stack.push(value: U256(from: i))
+                    }
+
+                    m.evalLoop()
+                    let result = m.stack.pop()
+
+                    expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                    expect(result).to(beSuccess { value in
+                        expect(value).to(equal(U256(from: UInt64(n) + 1)))
+                    })
+
+                    expect(m.stack.length).to(equal(Int(n) + 1))
+                    expect(m.gas.remaining).to(equal(7))
+                }
+            }
+
+            it("with OutOfGas result") {
+                var m = Self.machineLowGas
+
+                for i in (1 ... UInt64(16)).reversed() {
+                    let _ = m.stack.push(value: U256(from: i))
+                }
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(16))
+                expect(m.gas.remaining).to(equal(1))
+            }
+        }
+
+        it("check stack underflow for empty stack") {
+            var m = TestMachine.machine(opcode: Opcode.DUP1, gasLimit: 10)
+
+            m.evalLoop()
+            expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+            expect(m.stack.length).to(equal(0))
+            expect(m.gas.remaining).to(equal(7))
+        }
+
+        it("check stack underflow for DUP1..DUP16") {
+            for n in 0 ... UInt8(15) {
+                var m = TestMachine.machine(rawCode: [Opcode.DUP1.rawValue + n], gasLimit: 10)
+                if n > 0 {
+                    for i in (1 ... UInt64(n)).reversed() {
+                        let _ = m.stack.push(value: U256(from: i))
+                    }
+                }
+
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m.stack.length).to(equal(Int(n)))
+                expect(m.gas.remaining).to(equal(7))
+            }
+        }
+
+        it("check stack overflow for DUP1..DUP16") {
+            for n in 0 ... UInt8(15) {
+                var m = TestMachine.machine(rawCode: [Opcode.DUP1.rawValue + n], gasLimit: 10)
+                for i in 1 ... UInt64(m.stack.limit) {
+                    let _ = m.stack.push(value: U256(from: i))
+                }
+
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackOverflow))))
+                expect(m.stack.length).to(equal(m.stack.limit))
+                expect(m.gas.remaining).to(equal(7))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/InstructionsTests/Stack/SwapTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Stack/SwapTests.swift
@@ -55,7 +55,7 @@ final class InstructionSwapSpec: QuickSpec {
             m.evalLoop()
             expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
             expect(m.stack.length).to(equal(0))
-            expect(m.gas.remaining).to(equal(10))
+            expect(m.gas.remaining).to(equal(7))
         }
 
         it("check stack underflow for SWAP1..SWAP16") {
@@ -68,7 +68,7 @@ final class InstructionSwapSpec: QuickSpec {
                 m.evalLoop()
                 expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
                 expect(m.stack.length).to(equal(Int(n) + 1))
-                expect(m.gas.remaining).to(equal(10))
+                expect(m.gas.remaining).to(equal(7))
             }
         }
     }

--- a/Tests/cli-test-runner
+++ b/Tests/cli-test-runner
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+swift test 2>&1 | awk '
+/error:/ {
+    # Use regular expression to capture required parts
+    # Regex Breakdown:
+    # ^(.+\/)?([^:]+\.swift):([0-9]+): error: -\[(.*?)\] : expected to equal <([^>]+)>, got <([^>]+)>
+    regex = "^(.+\\/)?([^:]+\\.swift):([0-9]+): error: -\\[(.*?)\\] : expected to (.*), got <([^>]+)>"
+    if (match($0, regex, m)) {
+        # m[2]: Filename (e.g., AddTests.swift)
+        # m[3]: Line number (e.g., 15)
+        # m[4]: Test name (e.g., PrimitiveTypesTests.ArithmeticAddSpec overflowAdd, when adding zero to zero, returns zero without overflow)
+        # m[5]: Expected value (e.g., FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+        # m[6]: Got value (e.g., 0000000000000000000000000000000000000000000000000000000000000000)
+        
+        BOLD = "\033[1m"
+        GREY = "\033[90m"
+        RESET = "\033[0m"
+
+        # Print Filename:LineNumber in Bold
+        printf BOLD "%s:%s " RESET, m[2], m[3]
+
+        # Print Test Name in Grey
+        printf GREY "%s" RESET "\n", m[4]
+        
+        # Print expected value with tab
+        printf GREY "expect: " RESET
+        print m[5]
+        
+        # Print "got:   ActualValue"
+        printf GREY "got:    " RESET
+        print m[6]
+        print "_________________________________"
+    }
+}
+'


### PR DESCRIPTION
## Description

🚀 Added new EVM instructions.

➡️ Added opcode `DUP1 .. DUP16` instructions execution.
➡️ Added tests for opcodes and instructions `DUP`.
⚠️ Refactored tests for all gas calculations to prioritize gas cost

