### PR TITLE
Feat: Add opcodes STOP, JUMP, JUMPI, JUMPDEST

### DIFF
--- a/Sources/Interpreter/Gas.swift
+++ b/Sources/Interpreter/Gas.swift
@@ -69,6 +69,8 @@ enum GasConstant {
     static let VERYLOW: UInt64 = 3
     static let LOW: UInt64 = 5
     static let MID: UInt64 = 8
+    static let HIGH: UInt64 = 10
+    static let JUMPDEST: UInt64 = 1
     static let EXP: UInt64 = 10
 
     // TODO: Add hard fork config

--- a/Sources/Interpreter/Instructions/Bitwise.swift
+++ b/Sources/Interpreter/Instructions/Bitwise.swift
@@ -188,8 +188,8 @@ enum BItwiseInstructions {
 
             var newValue = U256.ZERO
             if op1 < U256(from: 32) {
-                // Force get UInt, because we know it is less than 32
-                let o = Int(op1.getUInt!)
+                // Force get Int, because we know it is less than 32
+                let o = op1.getInt!
                 for i in 0 ..< 8 {
                     let t = 255 - (7 - i + 8 * o)
                     let value = (op2 >> t) & U256(from: 1)
@@ -214,8 +214,8 @@ enum BItwiseInstructions {
 
             var newValue = U256.ZERO
             if !op2.isZero, op1 < U256(from: 256) {
-                // Force get UInt, because we know it is less than 256
-                let shift = Int(op1.getUInt!)
+                // Force get Int, because we know it is less than 256
+                let shift = op1.getInt!
                 newValue = op2 << shift
             }
             try m.stack.push(value: newValue).get()
@@ -235,8 +235,8 @@ enum BItwiseInstructions {
 
             var newValue = U256.ZERO
             if !op2.isZero, op1 < U256(from: 256) {
-                // Force get UInt, because we know it is less than 256
-                let shift = Int(op1.getUInt!)
+                // Force get Int, because we know it is less than 256
+                let shift = op1.getInt!
                 newValue = op2 >> shift
             }
             try m.stack.push(value: newValue).get()
@@ -264,8 +264,8 @@ enum BItwiseInstructions {
                     newValue = I256(from: [1, 0, 0, 0], signExtend: true).toU256
                 }
             } else {
-                // Force get UInt, because we know it is less than 256
-                let shift = Int(op1.getUInt!)
+                // Force get Int, because we know it is less than 256
+                let shift = op1.getInt!
                 // Check is positive number
                 if !iOp2.signExtend {
                     // Shift Right

--- a/Sources/Interpreter/Instructions/Control.swift
+++ b/Sources/Interpreter/Instructions/Control.swift
@@ -1,0 +1,86 @@
+import PrimitiveTypes
+
+/// EVM Control instructions
+enum ControlInstructions {
+    static func pc(machine m: inout Machine) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.BASE) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            let newValue = UInt64(m.pc)
+            try m.stack.push(value: U256(from: newValue)).get()
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
+
+    static func stop(machine m: inout Machine) {
+        m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Success(Machine.ExitSuccess.Stop))
+    }
+
+    static func jumpDest(machine m: inout Machine) {
+        if !m.gas.recordCost(cost: GasConstant.JUMPDEST) {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+            return
+        }
+    }
+
+    static func jump(machine m: inout Machine) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.MID) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            // Get jump destination
+            let target = try m.stack.pop().get()
+            guard let dest = target.getInt else {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.IntOverflow))
+                return
+            }
+
+            // Validate jump destination
+            if m.isValidJumpDestination(at: dest) {
+                m.machineStatus = Machine.MachineStatus.Jump(dest)
+            } else {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.InvalidJump))
+            }
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
+
+    static func jumpi(machine m: inout Machine) {
+        do {
+            if !m.gas.recordCost(cost: GasConstant.HIGH) {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
+                return
+            }
+
+            // Get jump destination
+            let target = try m.stack.pop().get()
+            let value = try m.stack.pop().get()
+
+            if value.isZero {
+                m.machineStatus = Machine.MachineStatus.Continue
+                return
+            }
+
+            guard let dest = target.getInt else {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.IntOverflow))
+                return
+            }
+
+            // Validate jump destination
+            if m.isValidJumpDestination(at: dest) {
+                m.machineStatus = Machine.MachineStatus.Jump(dest)
+            } else {
+                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.InvalidJump))
+            }
+        } catch {
+            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
+        }
+    }
+}

--- a/Sources/Interpreter/Instructions/System.swift
+++ b/Sources/Interpreter/Instructions/System.swift
@@ -15,18 +15,4 @@ enum SystemInstructions {
             m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
         }
     }
-
-    static func pc(machine m: inout Machine) {
-        do {
-            if !m.gas.recordCost(cost: GasConstant.BASE) {
-                m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas))
-                return
-            }
-
-            let newValue = UInt64(m.pc)
-            try m.stack.push(value: U256(from: newValue)).get()
-        } catch {
-            m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(error))
-        }
-    }
 }

--- a/Sources/Interpreter/Opcodes.swift
+++ b/Sources/Interpreter/Opcodes.swift
@@ -228,6 +228,15 @@ public enum Opcode: UInt8, CustomStringConvertible {
     /// Opcode index
     var index: Int { Int(rawValue) }
 
+    /// Whether the opcode is a push opcode. And return push count identifier
+    var isPush: Int? {
+        if (Self.PUSH1.rawValue ... Self.PUSH32.rawValue).contains(self.rawValue) {
+            return self.index - Self.PUSH1.index + 1
+        } else {
+            return nil
+        }
+    }
+
     var name: String {
         switch self {
         case .STOP: "STOP"

--- a/Sources/PrimitiveTypes/BigUInt.swift
+++ b/Sources/PrimitiveTypes/BigUInt.swift
@@ -68,7 +68,26 @@ public extension BigUInt {
     ///   - `UInt` must be less than or equal to `UInt64(UInt.max)`. On 32-bit systems. For 64-bit systems always successful.
     ///     `nil` corresponds to 32-bit systems, when `UInt` is greater than `UInt32.max`.
     var getUInt: UInt? {
-        UInt(exactly: self.BYTES[0])
+        for i in 1 ..< Int(Self.numberBase) {
+            if self.BYTES[i] != 0 {
+                return nil
+            }
+        }
+        return UInt(exactly: self.BYTES[0])
+    }
+
+    /// Get int value from `BigUInt`.
+    ///
+    /// - Returns:
+    ///   - `Int` must be less than or equal to `UInt64(Int.max)`. On 32-bit systems. For 64-bit systems always successful.
+    ///     `nil` corresponds to 32-bit systems, when `Int` is greater than `Int32.max`.
+    var getInt: Int? {
+        for i in 1 ..< Int(Self.numberBase) {
+            if self.BYTES[i] != 0 {
+                return nil
+            }
+        }
+        return Int(exactly: self.BYTES[0])
     }
 
     /// Calculate is `BigUInt` value zero

--- a/Tests/InterpreterTests/InstructionsTests/Control/JumpITests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/JumpITests.swift
@@ -1,0 +1,113 @@
+
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionJumpiSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.JUMPI, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction JUMPI") {
+            it("Correct JUMPI") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.PUSH1.rawValue, 0x6, Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                expect(m.pc).to(equal(7))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(3))
+            }
+
+            it("zero value") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x0, Opcode.PUSH1.rawValue, 0x6, Opcode.JUMPI.rawValue, Opcode.JUMPDEST.rawValue, Opcode.JUMPDEST.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 21)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                expect(m.pc).to(equal(8))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(2))
+            }
+
+            it("Invalid JUMPI to PUSH1 range") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.PUSH1.rawValue, 0x3, Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.InvalidJump))))
+                expect(m.pc).to(equal(4))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(4))
+            }
+
+            it("Invalid JUMP to non JUMPDEST opcode") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.PUSH1.rawValue, 0x4, Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.InvalidJump))))
+                expect(m.pc).to(equal(4))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(4))
+            }
+
+            it("JUMPDEST too large") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.PUSH8.rawValue, 0x80, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
+                expect(m.pc).to(equal(11))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(4))
+            }
+
+            it("with OutOfGas result") {
+                var m = Self.machineLowGas
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(1))
+            }
+
+            it("with OutOfGas result for JUMPDEST") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.PUSH1.rawValue, 0x6, Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 16)
+
+                m.evalLoop()
+
+                m.evalLoop()
+
+                expect(m.pc).to(equal(6))
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(0))
+            }
+
+            it("check stack underflow for partly empty stack") {
+                var m = TestMachine.machine(opcode: Opcode.JUMPI, gasLimit: 10)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(0))
+            }
+
+            it("check stack underflow for empty stack - empty target") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1,  Opcode.JUMPI.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/InstructionsTests/Control/JumpTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/JumpTests.swift
@@ -1,0 +1,90 @@
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionJumpSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.JUMP, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction JUMP") {
+            it("Correct JUMP") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x4, Opcode.JUMP.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                expect(m.pc).to(equal(5))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(8))
+            }
+
+            it("Invalid JUMP to PUSH1 range") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x1, Opcode.JUMP.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.InvalidJump))))
+                expect(m.pc).to(equal(2))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(9))
+            }
+
+            it("Invalid JUMP to non JUMPDEST opcode") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x3, Opcode.JUMP.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.InvalidJump))))
+                expect(m.pc).to(equal(2))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(9))
+            }
+
+            it("JUMPDEST too large") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH8.rawValue, 0x80, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, Opcode.JUMP.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 20)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.IntOverflow))))
+                expect(m.pc).to(equal(9))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(9))
+            }
+
+            it("with OutOfGas result") {
+                var m = Self.machineLowGas
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(1))
+            }
+
+            it("with OutOfGas result for JUMPDEST") {
+                var m = TestMachine.machine(rawCode: [Opcode.PUSH1.rawValue, 0x4, Opcode.JUMP.rawValue, Opcode.PC.rawValue, Opcode.JUMPDEST.rawValue], gasLimit: 11)
+
+                m.evalLoop()
+
+                m.evalLoop()
+
+                expect(m.pc).to(equal(4))
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(0))
+            }
+
+            it("check stack underflow for empty stack") {
+                var m = TestMachine.machine(opcode: Opcode.JUMP, gasLimit: 10)
+
+                m.evalLoop()
+                expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(2))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/InstructionsTests/Control/PcTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/PcTests.swift
@@ -40,6 +40,7 @@ final class InstructionPcSpec: QuickSpec {
                     })
                 }
 
+                expect(m.pc).to(equal(4))
                 expect(m.stack.length).to(equal(0))
                 expect(m.gas.remaining).to(equal(2))
             }

--- a/Tests/InterpreterTests/InstructionsTests/Control/StopTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/Control/StopTests.swift
@@ -1,0 +1,40 @@
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class InstructionStopSpec: QuickSpec {
+    override class func spec() {
+        describe("Instruction STOP") {
+            it("Stop immediately") {
+                var m = TestMachine.machine(opcodes: [Opcode.STOP, Opcode.PC], gasLimit: 10)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                expect(m.pc).to(equal(0))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(10))
+            }
+
+            it("Stop after multiple instructions") {
+                var m = TestMachine.machine(opcodes: [Opcode.PC, Opcode.PC, Opcode.PC, Opcode.STOP], gasLimit: 10)
+
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+
+                for i in (0 ..< 3).reversed() {
+                    let result = m.stack.pop()
+                    expect(result).to(beSuccess { value in
+                        expect(value).to(equal(U256(from: UInt64(i))))
+                    })
+                }
+                expect(m.pc).to(equal(3))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(4))
+            }
+        }
+    }
+}

--- a/Tests/InterpreterTests/JumpTableTests.swift
+++ b/Tests/InterpreterTests/JumpTableTests.swift
@@ -1,0 +1,30 @@
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class JumpTableSpec: QuickSpec {
+    override class func spec() {
+        describe("Machine JumptTable") {
+            it("check opcodes index and out of code size") {
+                let m = TestMachine.machine(opcodes: [Opcode.ADD, Opcode.PC, Opcode.SUB], gasLimit: 10)
+                for i in 0 ..< m.codeSize + 5 {
+                    let isValue = m.isValidJumpDestination(at: i)
+                    expect(isValue).to(equal(false))
+                }
+            }
+
+            it("check in PUSH range") {
+                let m = TestMachine.machine(rawCode: [Opcode.ADD.rawValue, Opcode.JUMPDEST.rawValue, Opcode.PUSH2.rawValue, Opcode.JUMPDEST.rawValue, Opcode.JUMPDEST.rawValue, Opcode.JUMPDEST.rawValue, Opcode.ADD.rawValue], gasLimit: 20)
+
+                expect(m.isValidJumpDestination(at: 0)).to(equal(false))
+                expect(m.isValidJumpDestination(at: 1)).to(equal(true))
+                expect(m.isValidJumpDestination(at: 2)).to(equal(false))
+                expect(m.isValidJumpDestination(at: 3)).to(equal(false))
+                expect(m.isValidJumpDestination(at: 4)).to(equal(false))
+                expect(m.isValidJumpDestination(at: 5)).to(equal(true))
+                expect(m.isValidJumpDestination(at: 6)).to(equal(false))
+            }
+        }
+    }
+}

--- a/Tests/PrimitiveTypesTests/I256Tests.swift
+++ b/Tests/PrimitiveTypesTests/I256Tests.swift
@@ -170,7 +170,21 @@ final class I256Spec: QuickSpec {
                         0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0xAC, 2,
                     ])
-                    expect(0x0000_00C1_0302_010F).to(equal(val.getUInt))
+                    expect(val.getUInt).to(beNil())
+
+                    let val2 = U256(from: [0xFFFF, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getUInt))
+                }
+
+                it("getInt") {
+                    let val = U256.fromLittleEndian(from: [
+                        0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0xAC, 2,
+                    ])
+                    expect(val.getInt).to(beNil())
+
+                    let val2 = U256(from: [0xFFFF, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getInt))
                 }
             }
 

--- a/Tests/PrimitiveTypesTests/U128Tests.swift
+++ b/Tests/PrimitiveTypesTests/U128Tests.swift
@@ -156,7 +156,20 @@ final class U128Spec: QuickSpec {
                     let val = U128.fromLittleEndian(from: [
                         0xf, 1, 2, 3, 0xc1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xac, 2,
                     ])
-                    expect(0x000000c10302010f).to(equal(val.getUInt))
+                    expect(val.getUInt).to(beNil())
+
+                    let val2 = U128(from: [0xffff, 0])
+                    expect(0xffff).to(equal(val2.getUInt))
+                }
+
+                it("getInt") {
+                    let val = U128.fromLittleEndian(from: [
+                        0xf, 1, 2, 3, 0xc1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xac, 2,
+                    ])
+                    expect(val.getInt).to(beNil())
+
+                    let val2 = U128(from: [0xffff, 0])
+                    expect(0xffff).to(equal(val2.getInt))
                 }
             }
 

--- a/Tests/PrimitiveTypesTests/U256Tests.swift
+++ b/Tests/PrimitiveTypesTests/U256Tests.swift
@@ -163,7 +163,21 @@ final class U256Spec: QuickSpec {
                         0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0xAC, 2,
                     ])
-                    expect(0x0000_00C1_0302_010F).to(equal(val.getUInt))
+                    expect(val.getUInt).to(beNil())
+
+                    let val2 = U256(from: [0xFFFF, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getUInt))
+                }
+
+                it("getInt") {
+                    let val = U256.fromLittleEndian(from: [
+                        0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0xAC, 2,
+                    ])
+                    expect(val.getInt).to(beNil())
+
+                    let val2 = U256(from: [0xFFFF, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getInt))
                 }
             }
 

--- a/Tests/PrimitiveTypesTests/U512Tests.swift
+++ b/Tests/PrimitiveTypesTests/U512Tests.swift
@@ -192,7 +192,21 @@ final class U512Spec: QuickSpec {
                         0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                         0, 0xAC, 2,
                     ])
-                    expect(0x0000_00C1_0302_010F).to(equal(val.getUInt))
+                    expect(val.getUInt).to(beNil())
+
+                    let val2 = U512(from: [0xFFFF, 0, 0, 0, 0, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getUInt))
+                }
+
+                it("getInt") {
+                    let val = U512.fromLittleEndian(from: [
+                        0xF, 1, 2, 3, 0xC1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0xAC, 2,
+                    ])
+                    expect(val.getInt).to(beNil())
+
+                    let val2 = U512(from: [0xFFFF, 0, 0, 0, 0, 0, 0, 0])
+                    expect(0xFFFF).to(equal(val2.getInt))
                 }
             }
 


### PR DESCRIPTION
## Description

🚀 Added new EVM `control` instructions.

➡️ Added opcode `STOP` instructions execution.
➡️ Added opcode `JUMP` instructions execution.
➡️ Added opcode `JUMPI` instructions execution.
➡️ Added opcode `JUMPDEST` instructions execution.
➡️ Added tests for opcodes and added instructions.
➡️ Added `JumpTable` validation for execution `Machine`
➡️ Added tests for `JumpTable` validation
➡️ Refactored `Instructions Control` structures and moved `PC` to `Control`
