### PR TITLE
Feat: add MSTORE instruction

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftEVM",
-    platforms: [
-        .macOS(.v14),
-        .iOS(.v17),
-        .tvOS(.v17),
-        .watchOS(.v10),
-        .visionOS(.v1)
-    ],
     products: [
         .library(
             name: "EVM",

--- a/Sources/Interpreter/Instructions/MemoryInstructions.swift
+++ b/Sources/Interpreter/Instructions/MemoryInstructions.swift
@@ -20,4 +20,27 @@ enum MemoryInstructions {
         let val = m.memory.get(offset: index, size: 32)
         m.stackPush(value: U256.fromBigEndian(from: val))
     }
+
+    static func mstore(machine m: inout Machine) {
+        if !m.gasRecordCost(cost: GasConstant.VERYLOW) {
+            return
+        }
+
+        guard let rawIndex = m.stackPop(),
+              let value = m.stackPop()
+        else {
+            return
+        }
+
+        // This situation possible only for 32-bit context (for example wasm32)
+        guard let index = rawIndex.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+
+        guard m.resizeMemoryAndRecordGas(offset: index, size: 32) else {
+            return
+        }
+
+        if case .failure(let err) = m.memory.set(offset: index, value: value.toBigEndian, size: 32) {
+            m.machineStatus = Machine.MachineStatus.Exit(err)
+        }
+    }
 }

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -208,6 +208,7 @@ public struct Machine {
 
         // Memory
         table[Opcode.MLOAD.index] = MemoryInstructions.mload
+        table[Opcode.MSTORE.index] = MemoryInstructions.mstore
 
         return table
     }()

--- a/Sources/Interpreter/Memory.swift
+++ b/Sources/Interpreter/Memory.swift
@@ -127,7 +127,7 @@ public class Memory {
 
         // After all validation check we can guaranty that copySize is non zero
         _ = result.withUnsafeMutableBytes { dest in
-            memcpy(dest.baseAddress, buf.advanced(by: intOffset), copySize)
+            memcpy(dest.baseAddress!, buf.advanced(by: intOffset), copySize)
         }
         return result
     }
@@ -174,7 +174,7 @@ public class Memory {
         return value.withUnsafeBytes { src in
             // Get correct range for copy
             let copyCount = min(intSize, value.count)
-            memcpy(buf.advanced(by: intOffset), src.baseAddress, copyCount)
+            memcpy(buf.advanced(by: intOffset), src.baseAddress!, copyCount)
 
             if intSize > value.count {
                 memset(buf.advanced(by: intOffset + value.count), 0, intSize - value.count)

--- a/Sources/PrimitiveTypes/DivModUtils.swift
+++ b/Sources/PrimitiveTypes/DivModUtils.swift
@@ -22,7 +22,7 @@ enum DivModUtils {
     }
 
     /// divMod for `UInt128` types
-    @available(macOS 15.0, *)
+    @available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)
     static func divModWordU128(hi: UInt64, lo: UInt64, y: UInt64) -> (quotient: UInt64, remainder: UInt64) {
         // Construct the 128-bit number from hi and lo
         let x = (UInt128(hi) << 64) + UInt128(lo)

--- a/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MLoadTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MLoadTests.swift
@@ -28,6 +28,9 @@ final class MLoadSpec: QuickSpec {
             var m = TestMachine.machine(opcode: Opcode.MLOAD, gasLimit: 10)
             m.evalLoop()
             expect(m.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+            expect(m.gas.remaining).to(equal(7))
+            expect(m.gas.memoryGas.numWords).to(equal(0))
+            expect(m.gas.memoryGas.gasCost).to(equal(0))
         }
 
         it("gas overflow for resized memoryGasCost") {

--- a/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStoreTests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStoreTests.swift
@@ -1,0 +1,99 @@
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class MStoreSpec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction MSTORE") {
+            it("with OutOfGas result for index=0") {
+                var m = Self.machineLowGas
+
+                let _ = m.stack.push(value: U256(from: 0))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(1))
+                expect(m.gas.remaining).to(equal(1))
+                expect(m.gas.memoryGas.numWords).to(equal(0))
+                expect(m.gas.memoryGas.gasCost).to(equal(0))
+            }
+
+            it("check stack underflow errors is as expected") {
+                var m1 = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 10)
+                m1.evalLoop()
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m1.gas.remaining).to(equal(7))
+                expect(m1.gas.memoryGas.numWords).to(equal(0))
+                expect(m1.gas.memoryGas.gasCost).to(equal(0))
+
+                var m2 = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 10)
+                let _ = m2.stack.push(value: U256(from: 0))
+                m2.evalLoop()
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m2.gas.remaining).to(equal(7))
+                expect(m2.gas.memoryGas.numWords).to(equal(0))
+                expect(m2.gas.memoryGas.gasCost).to(equal(0))
+            }
+
+            it("gas overflow for resized memoryGasCost") {
+                var m = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 10)
+                // Value
+                let _ = m.stack.push(value: U256(from: 1))
+                // Index
+                let _ = m.stack.push(value: U256(from: 97))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+                expect(m.gas.memoryGas.numWords).to(equal(5))
+                expect(m.gas.memoryGas.gasCost).to(equal(40))
+            }
+
+            it("error MemoryOperation copyLimitExceeded") {
+                var m = TestMachine.machine(opcodes: [Opcode.MSTORE], gasLimit: 100, memoryLimit: 100)
+
+                let _ = m.stack.push(value: U256(from: 1))
+                let _ = m.stack.push(value: U256(from: 100))
+                m.evalLoop()
+
+                expect(m.machineStatus)
+                    .to(equal(Machine.MachineStatus.Exit(.Error(.MemoryOperation(.SetLimitExceeded)))))
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(57))
+                expect(m.gas.memoryGas.numWords).to(equal(5))
+                expect(m.gas.memoryGas.gasCost).to(equal(40))
+            }
+
+            it("success") {
+                var m = TestMachine.machine(opcode: Opcode.MSTORE, gasLimit: 100)
+                var value = [UInt8](repeating: 0, count: 32)
+                value.replaceSubrange(0 ..< 14, with: [UInt8](repeating: 3, count: 14))
+
+                let _ = m.stack.push(value: U256.fromBigEndian(from: value))
+                let _ = m.stack.push(value: U256(from: 33))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                let resVal: [UInt8] = m.memory.get(offset: 30, size: 18)
+
+                var expectedValue = [UInt8](repeating: 0, count: 16)
+                expectedValue.replaceSubrange(3 ... 14, with: [UInt8](repeating: 3, count: 14))
+                expect(resVal).to(equal(expectedValue))
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(79))
+                expect(m.gas.memoryGas.numWords).to(equal(3))
+                expect(m.gas.memoryGas.gasCost).to(equal(18))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

🚀 Added `MSTORE` instruction operation and tests
➡️  Added strict rules for memory access for memory.address access
➡️  For correct build process for UInt128 types, changed most latest Apple  devices OS:
- iOS 18.0
- tvOS 18.0
- watchOS 11.0
- visionOS 2.0