### PR TITLE
 Feat: add MSTORE8 instruction

### DIFF
--- a/Sources/Interpreter/Instructions/MemoryInstructions.swift
+++ b/Sources/Interpreter/Instructions/MemoryInstructions.swift
@@ -43,4 +43,28 @@ enum MemoryInstructions {
             m.machineStatus = Machine.MachineStatus.Exit(err)
         }
     }
+
+    static func mstore8(machine m: inout Machine) {
+        if !m.gasRecordCost(cost: GasConstant.VERYLOW) {
+            return
+        }
+
+        guard let rawIndex = m.stackPop(),
+              let value = m.stackPop()
+        else {
+            return
+        }
+
+        // This situation possible only for 32-bit context (for example wasm32)
+        guard let index = rawIndex.getUInt else { m.machineStatus = Machine.MachineStatus.Exit(Machine.ExitReason.Error(.OutOfGas)); return }
+
+        guard m.resizeMemoryAndRecordGas(offset: index, size: 1) else {
+            return
+        }
+
+        let byteValue = UInt8(value.BYTES[0] & 0xFF)
+        if case .failure(let err) = m.memory.set(offset: index, value: [byteValue], size: 1) {
+            m.machineStatus = Machine.MachineStatus.Exit(err)
+        }
+    }
 }

--- a/Sources/Interpreter/Machine.swift
+++ b/Sources/Interpreter/Machine.swift
@@ -209,6 +209,7 @@ public struct Machine {
         // Memory
         table[Opcode.MLOAD.index] = MemoryInstructions.mload
         table[Opcode.MSTORE.index] = MemoryInstructions.mstore
+        table[Opcode.MSTORE8.index] = MemoryInstructions.mstore8
 
         return table
     }()

--- a/Sources/PrimitiveTypes/DivModUtils.swift
+++ b/Sources/PrimitiveTypes/DivModUtils.swift
@@ -35,7 +35,7 @@ enum DivModUtils {
     }
 
     static func divModWord(hi: UInt64, lo: UInt64, y: UInt64) -> (quotient: UInt64, remainder: UInt64) {
-        if #available(macOS 15.0, *) {
+        if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
             return self.divModWordU128(hi: hi, lo: lo, y: y)
         } else {
             return self.divModWord64(hi: hi, lo: lo, y: y)

--- a/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStore8Tests.swift
+++ b/Tests/InterpreterTests/InstructionsTests/MemoryInstructions/MStore8Tests.swift
@@ -1,0 +1,95 @@
+
+@testable import Interpreter
+import Nimble
+import PrimitiveTypes
+import Quick
+
+final class MStore8Spec: QuickSpec {
+    @MainActor
+    static let machineLowGas = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 1)
+
+    override class func spec() {
+        describe("Instruction MSTORE8") {
+            it("with OutOfGas result for index=0") {
+                var m = Self.machineLowGas
+
+                let _ = m.stack.push(value: U256(from: 0))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(1))
+                expect(m.gas.remaining).to(equal(1))
+                expect(m.gas.memoryGas.numWords).to(equal(0))
+                expect(m.gas.memoryGas.gasCost).to(equal(0))
+            }
+
+            it("check stack underflow errors is as expected") {
+                var m1 = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 10)
+                m1.evalLoop()
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m1.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m1.gas.remaining).to(equal(7))
+                expect(m1.gas.memoryGas.numWords).to(equal(0))
+                expect(m1.gas.memoryGas.gasCost).to(equal(0))
+
+                var m2 = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 10)
+                let _ = m2.stack.push(value: U256(from: 0))
+                m2.evalLoop()
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m2.machineStatus).to(equal(.Exit(.Error(.StackUnderflow))))
+                expect(m2.gas.remaining).to(equal(7))
+                expect(m2.gas.memoryGas.numWords).to(equal(0))
+                expect(m2.gas.memoryGas.gasCost).to(equal(0))
+            }
+
+            it("gas overflow for resized memoryGasCost") {
+                var m = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 10)
+                // Value
+                let _ = m.stack.push(value: U256(from: 1))
+                // Index
+                let _ = m.stack.push(value: U256(from: 97))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Error(.OutOfGas))))
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(7))
+                expect(m.gas.memoryGas.numWords).to(equal(4))
+                expect(m.gas.memoryGas.gasCost).to(equal(28))
+            }
+
+            it("error MemoryOperation copyLimitExceeded") {
+                var m = TestMachine.machine(opcodes: [Opcode.MSTORE8], gasLimit: 100, memoryLimit: 100)
+
+                let _ = m.stack.push(value: U256(from: 1))
+                let _ = m.stack.push(value: U256(from: 100))
+                m.evalLoop()
+
+                expect(m.machineStatus)
+                    .to(equal(Machine.MachineStatus.Exit(.Error(.MemoryOperation(.SetLimitExceeded)))))
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(69))
+                expect(m.gas.memoryGas.numWords).to(equal(4))
+                expect(m.gas.memoryGas.gasCost).to(equal(28))
+            }
+
+            it("success") {
+                var m = TestMachine.machine(opcode: Opcode.MSTORE8, gasLimit: 100)
+
+                let _ = m.stack.push(value: U256(from: 3))
+                let _ = m.stack.push(value: U256(from: 33))
+                m.evalLoop()
+
+                expect(m.machineStatus).to(equal(.Exit(.Success(.Stop))))
+                let resVal: [UInt8] = m.memory.get(offset: 32, size: 3)
+
+                expect(resVal).to(equal([0, 3, 0]))
+
+                expect(m.stack.length).to(equal(0))
+                expect(m.gas.remaining).to(equal(87))
+                expect(m.gas.memoryGas.numWords).to(equal(2))
+                expect(m.gas.memoryGas.gasCost).to(equal(10))
+            }
+        }
+    }
+}

--- a/Tests/PrimitiveTypesTests/ArithmeticTests/FuzzDivTests.swift
+++ b/Tests/PrimitiveTypesTests/ArithmeticTests/FuzzDivTests.swift
@@ -6,7 +6,7 @@ import Quick
 final class FuzzDivRemSpec: QuickSpec {
     override class func spec() {
         describe("Fuzz divRem") {
-            if #available(macOS 15.0, *) {
+            if #available(macOS 15.0, iOS 18.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
                 func splitUInt128(_ value: UInt128) -> (high: UInt64, low: UInt64) {
                     let high = UInt64(value >> 64)
                     let low = UInt64(value & 0xFFFFFFFFFFFFFFFF)


### PR DESCRIPTION
## Description

🚀 Added `MSTORE8` instruction operation and tests
➡️  For correct build process for UInt128 types, changed most latest Apple  devices OS:
- iOS 18.0
- tvOS 18.0
- watchOS 11.0
- visionOS 2.0