### PR TITLE
Feat: extend memory substate tests

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe1afcdb21e9d4638ecacff0122c3eec8601c9c2a5927e9d55f472125b5e8d90",
+  "originHash" : "3718a4c996e6e01b529e1e2b301eda2b099c501e8b7a759fb9c6ef9266db1246",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "7795df4fff1a9cd231fe4867ae54f4dc5f5734f9",
-        "version" : "13.7.1"
+        "revision" : "cc945f7bdf3b485adedc315e18685c065059b4ca",
+        "version" : "13.8.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-algorithms.git",
       "state" : {
-        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
-        "version" : "1.2.0"
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
-        "version" : "1.5.0"
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics.git",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
       }
     }
   ],

--- a/Sources/Interpreter/Accounts.swift
+++ b/Sources/Interpreter/Accounts.swift
@@ -36,6 +36,11 @@ public struct BasicAccount: Equatable, Sendable {
     }
 }
 
+extension BasicAccount {
+    /// A default `BasicAccount` instance with a balance of zero and a nonce of zero.
+    static let `default` = BasicAccount(balance: U256.ZERO, nonce: U256.ZERO)
+}
+
 /// Account state information.
 public struct StateAccount: Equatable, Sendable {
     /// Basic account information.

--- a/Sources/Interpreter/Authorization.swift
+++ b/Sources/Interpreter/Authorization.swift
@@ -56,12 +56,11 @@ public struct Authorization: Equatable, Sendable {
 
 public extension Authorization {
     /// Provides a default/zero instance of `Authorization`.
-    static var `default`: Authorization {
-        return Authorization(
+    static let `default` =
+        Authorization(
             authority: .ZERO,
             address: .ZERO,
             nonce: 0,
             isValid: false
         )
-    }
 }

--- a/Sources/Interpreter/MemoryState.swift
+++ b/Sources/Interpreter/MemoryState.swift
@@ -277,14 +277,6 @@ public class MemoryState {
         return parent?.knownStorage(address: address, key: key)
     }
 
-    /// Get known original storage value by address. This function is used to retrieve the original value of a storage slot by its address.
-    public func knownOriginalStorage(_ address: H160) -> H256? {
-        if let account = accounts[address], account.reset {
-            return H256.ZERO
-        }
-        return parent?.knownOriginalStorage(address)
-    }
-
     /// Check is account address is cold by address.
     public func isCold(_ address: H160) -> Bool {
         return recursiveIsCold { accessed in accessed.addresses.contains(address) }
@@ -752,13 +744,10 @@ extension MemoryState: Backend {
     }
 
     public func isEmptyStorage(address: H160) -> Bool {
-        return backend.isEmptyStorage(address: address)
+        backend.isEmptyStorage(address: address)
     }
 
     public func originalStorage(address: H160, index: H256) -> H256? {
-        if let value = knownOriginalStorage(address) {
-            return value
-        }
-        return backend.originalStorage(address: address, index: index)
+        backend.originalStorage(address: address, index: index)
     }
 }

--- a/Sources/Interpreter/MemoryState.swift
+++ b/Sources/Interpreter/MemoryState.swift
@@ -266,16 +266,6 @@ public class MemoryState {
         return parent?.knownAccount(address)
     }
 
-    /// Get known basic account data by address. This function is used to retrieve the basic data of an account by its address.
-    public func knownBasic(_ address: H160) -> BasicAccount? {
-        return knownAccount(address)?.basic
-    }
-
-    /// Get known account code by address. This function is used to retrieve the code of an account by its address.
-    public func knownCode(_ address: H160) -> [UInt8]? {
-        return knownAccount(address)?.code
-    }
-
     /// Get known storage value by address and key. This function is used to retrieve the value of a storage slot by its address and key.
     public func knownStorage(address: H160, key: H256) -> H256? {
         if let accountStorage = storages[address], let value = accountStorage[key] {
@@ -734,15 +724,31 @@ extension MemoryState: Backend {
     }
 
     public func basic(address: H160) -> BasicAccount {
-        return knownBasic(address) ?? backend.basic(address: address)
+        guard let basic = knownAccount(address)?.basic else {
+            let account = getAccountAndTouch(address)
+            return account.basic
+        }
+        return basic
     }
 
     public func code(address: H160) -> [UInt8] {
-        return knownCode(address) ?? backend.code(address: address)
+        guard let code = knownAccount(address)?.code else {
+            let code = backend.code(address: address)
+            // Cache code in the state for future accesses.
+            setCode(address: address, code: code)
+            return code
+        }
+        return code
     }
 
     public func storage(address: H160, index: H256) -> H256 {
-        return knownStorage(address: address, key: index) ?? backend.storage(address: address, index: index)
+        guard let value = knownStorage(address: address, key: index) else {
+            let value = backend.storage(address: address, index: index)
+            // Cache storage value in the state for future accesses.
+            setStorage(address: address, key: index, value: value)
+            return value
+        }
+        return value
     }
 
     public func isEmptyStorage(address: H160) -> Bool {

--- a/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
+++ b/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
@@ -10,44 +10,49 @@ final class MockBackend: Backend {
     var codes: [H160: [UInt8]] = [:]
     var storages: [H160: [H256: H256]] = [:]
 
+    let sender = H160(from: [UInt8](repeating: 0x0a, count: 20))
+    let address1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+    let coinBase = H160(from: [UInt8](repeating: 0x0b, count: 20))
+    let storageKey1 = H256(from: U256(from: 10).toBigEndian)
+
     func gasPrice() -> U256 {
-        .ZERO
+        U256(from: 333)
     }
 
     func origin() -> H160 {
-        .ZERO
+        sender
     }
 
     func blockHash(number: U256) -> H256 {
-        .ZERO
+        H256(from: U256(from: 100).toBigEndian)
     }
 
     func blockNumber() -> U256 {
-        .ZERO
+        U256(from: 1000)
     }
 
     func blockCoinbase() -> H160 {
-        .ZERO
+        coinBase
     }
 
     func blockTimestamp() -> U256 {
-        .ZERO
+        U256(from: 1234567890)
     }
 
     func blockDifficulty() -> U256 {
-        .ZERO
+        U256(from: 999)
     }
 
     func blockRandomness() -> H256? {
-        nil
+        H256(from: U256(from: 22).toBigEndian)
     }
 
     func blockGasLimit() -> U256 {
-        .ZERO
+        U256(from: 8000000)
     }
 
     func blockBaseFeePerGas() -> U256 {
-        .ZERO
+        U256(from: 300)
     }
 
     func chainId() -> U256 {
@@ -55,11 +60,11 @@ final class MockBackend: Backend {
     }
 
     func blobGasPrice() -> U128 {
-        U128.ZERO
+        U128(from: 410)
     }
 
     func getBlobHash(index: UInt) -> U256? {
-        nil
+        U256(from: 601)
     }
 
     func exists(address: H160) -> Bool {
@@ -67,21 +72,22 @@ final class MockBackend: Backend {
     }
 
     func basic(address: H160) -> BasicAccount {
-        accounts[address] ?? BasicAccount(balance: U256(from: 10), nonce: U256(from: 20))
+        if address == sender {
+            return BasicAccount(balance: U256(from: 3003), nonce: U256(from: 10))
+        }
+        return accounts[address] ?? BasicAccount.default
     }
 
     func code(address: H160) -> [UInt8] {
-        if codes[address] == nil {
-            codes[address] = [UInt8](repeating: 0x60, count: 10)
+        if address == sender {
+            return [10, 20, 30]
         }
         return codes[address] ?? []
     }
 
     func storage(address: H160, index: H256) -> H256 {
-        if storages[address] == nil {
-            var storage: [H256: H256] = [:]
-            storage[H256.ZERO] = H256(from: [123])
-            storages[address] = storage
+        if address == sender, index == storageKey1 {
+            return H256(from: U256(from: 555).toBigEndian)
         }
         return storages[address]?[index] ?? H256.ZERO
     }
@@ -100,73 +106,601 @@ final class MockBackend: Backend {
 final class MemoryStateSpec: QuickSpec {
     override class func spec() {
         describe("MemoryState") {
-            let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
-            let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
-            let key1 = H256.ZERO
-            let val1 = H256(from: [UInt8](repeating: 0xff, count: 32))
-
             context("Account lookups and Caching") {
-                it("should fetch account from backend and cache it locally") {
+                it("should fetch account from backend and cache it locally for balance and nonce") {
                     let backend = MockBackend()
-                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
 
                     // First call - triggers getAccountAndTouch
-                    let acc = state.getAccountAndTouch(addr1)
-                    expect(acc.basic.balance).to(equal(U256(from: 10)))
+                    let acc = state.getAccountAndTouch(backend.address1)
+                    expect(acc.basic.balance).to(equal(U256.ZERO))
 
-                    // Modify locally
-                    state.accounts[addr1]?.basic.setBalance(U256(from: 2000))
+                    // Modify locally. It's only for testing that local state is separate from backend.
+                    state.accounts[backend.address1]?.basic = BasicAccount(balance: U256(from: 2000), nonce: U256(from: 5))
 
                     // Verify local state changed but backend remains same
-                    expect(state.knownBasic(addr1)?.balance).to(equal(U256(from: 2000)))
-                    expect(backend.basic(address: addr1).balance).to(equal(U256(from: 10)))
+                    expect(state.basic(address: backend.address1).balance).to(equal(U256(from: 2000)))
+                    expect(backend.basic(address: backend.address1).balance).to(equal(U256.ZERO))
+                    expect(state.basic(address: backend.address1).nonce).to(equal(U256(from: 5)))
+                    expect(backend.basic(address: backend.address1).nonce).to(equal(U256.ZERO))
                 }
 
                 it("should lookup account recursively in parent states") {
                     let backend = MockBackend()
                     let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                    parentState.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 500), nonce: .ZERO), code: nil, reset: false)
+                    parentState.accounts[backend.address1] = StateAccount(basic: BasicAccount(balance: U256(from: 500), nonce: U256(from: 10)), code: [10, 20], reset: true)
 
                     let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
                     childState.parent = parentState
 
-                    expect(childState.knownAccount(addr1)).toNot(beNil())
-                    expect(childState.knownBasic(addr1)?.balance).to(equal(U256(from: 500)))
+                    let knownAcc = childState.knownAccount(backend.address1)
+                    expect(knownAcc).toNot(beNil())
+                    expect(knownAcc?.basic.balance).to(equal(U256(from: 500)))
+                    expect(knownAcc?.basic.nonce).to(equal(U256(from: 10)))
+                    expect(knownAcc?.code).to(equal([10, 20]))
+                    expect(knownAcc?.reset).to(equal(true))
+
+                    expect(childState.knownAccount(backend.address1)?.basic.balance).to(equal(U256(from: 500)))
+                    expect(childState.knownAccount(backend.address1)?.basic.nonce).to(equal(U256(from: 10)))
+                }
+            }
+
+            context("Account state Balance and Nonce Mutations") {
+                it("Deposit and withdraw for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    let acc = state.getAccountAndTouch(backend.sender)
+                    expect(acc.basic.balance).to(equal(U256(from: 3003)))
+
+                    state.deposit(address: backend.sender, value: U256(from: 1000))
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+
+                    let res = state.withdraw(address: backend.sender, value: U256(from: 2003))
+                    expect(res).to(beSuccess())
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 2000)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Deposit and withdraw for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    parentState.deposit(address: backend.sender, value: U256(from: 1000))
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+
+                    childState.deposit(address: backend.sender, value: U256(from: 1700))
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 5703)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+
+                    let res1 = parentState.withdraw(address: backend.sender, value: U256(from: 2003))
+                    expect(res1).to(beSuccess())
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 2000)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 5703)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+
+                    let res2 = childState.withdraw(address: backend.sender, value: U256(from: 1323))
+                    expect(res2).to(beSuccess())
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 2000)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 4380)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Deposit and Reset balance for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    let acc = state.getAccountAndTouch(backend.sender)
+                    expect(acc.basic.balance).to(equal(U256(from: 3003)))
+
+                    state.deposit(address: backend.sender, value: U256(from: 1000))
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+
+                    state.resetBalance(address: backend.sender)
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256.ZERO))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                }
+
+                it("Deposit and Reset balance for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    parentState.deposit(address: backend.sender, value: U256(from: 1000))
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+
+                    childState.deposit(address: backend.sender, value: U256(from: 1700))
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 4003)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 5703)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+
+                    parentState.resetBalance(address: backend.sender)
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256.ZERO))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 5703)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+
+                    childState.resetBalance(address: backend.sender)
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256.ZERO))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256.ZERO))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                }
+
+                it("withdraw with OutOfFunds") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    let acc = state.getAccountAndTouch(backend.sender)
+                    expect(acc.basic.balance).to(equal(U256(from: 3003)))
+
+                    let res = state.withdraw(address: backend.sender, value: U256(from: 3004))
+                    expect(res).to(beFailure { error in expect(error).to(equal(.OutOfFund)) })
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Increment nonce for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    let acc = state.getAccountAndTouch(backend.sender)
+                    expect(acc.basic.nonce).to(equal(U256(from: 10)))
+
+                    let res = state.incNonce(address: backend.sender)
+                    expect(res).to(beSuccess())
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.sender).nonce).to(equal(U256(from: 11)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Increment nonce for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    let res1 = parentState.incNonce(address: backend.sender)
+                    expect(res1).to(beSuccess())
+                    expect(parentState.basic(address: backend.sender).nonce).to(equal(U256(from: 11)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 11)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+
+                    let res2 = childState.incNonce(address: backend.sender)
+                    expect(res2).to(beSuccess())
+                    expect(parentState.basic(address: backend.sender).nonce).to(equal(U256(from: 11)))
+                    expect(childState.basic(address: backend.sender).nonce).to(equal(U256(from: 12)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Increment nonce with overflow for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    let acc = state.getAccountAndTouch(backend.sender)
+                    expect(acc.basic.nonce).to(equal(U256(from: 10)))
+
+                    // Force nonce to max value to test overflow
+                    state.accounts[backend.sender]?.basic.nonce = U256(from: UInt64.max)
+
+                    let res = state.incNonce(address: backend.sender)
+                    expect(res).to(beFailure { error in expect(error).to(equal(.MaxNonce)) })
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(backend.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.sender).nonce).to(equal(U256(from: UInt64.max)))
+                    expect(backend.basic(address: backend.sender).nonce).to(equal(U256(from: 10)))
+                }
+
+                it("Account code for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: MockBackend(), hardFork: .Berlin)
+
+                    expect(state.code(address: backend.sender)).to(equal([10, 20, 30]))
+                    expect(backend.code(address: backend.sender)).to(equal([10, 20, 30]))
+
+                    expect(state.knownAccount(backend.address1)?.code).to(beNil())
+                    expect(state.code(address: backend.address1)).to(equal([]))
+                    // After call `backend.code`, the knownAccount for address1 should be updated with empty code, so it should not be nil anymore.
+                    expect(state.knownAccount(backend.address1)?.code).to(equal([]))
+                    expect(backend.code(address: backend.address1)).to(equal([]))
+
+                    state.setCode(address: backend.sender, code: [8, 5, 3])
+                    state.setCode(address: backend.address1, code: [3, 5, 8])
+
+                    expect(state.code(address: backend.sender)).to(equal([8, 5, 3]))
+                    expect(backend.code(address: backend.sender)).to(equal([10, 20, 30]))
+                    expect(state.code(address: backend.address1)).to(equal([3, 5, 8]))
+                    expect(backend.code(address: backend.address1)).to(equal([]))
+                }
+            }
+
+            context("Account state gat basic and touch") {
+                it("Get basic for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.knownAccount(backend.sender)).to(beNil())
+                    expect(childState.knownAccount(backend.sender)).to(beNil())
+
+                    // Account cashed in parent state after getAccountAndTouch call
+                    expect(parentState.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    // Already cached in parent state
+                    expect(childState.knownAccount(backend.sender)?.basic.balance).to(equal(U256(from: 3003)))
+                    expect(childState.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+
+                    expect(parentState.knownAccount(backend.address1)).to(beNil())
+                    expect(childState.knownAccount(backend.address1)).to(beNil())
+
+                    expect(childState.basic(address: backend.address1).balance).to(equal(U256.ZERO))
+                    expect(parentState.knownAccount(backend.address1)).to(beNil())
+                    expect(childState.knownAccount(backend.address1)?.basic.balance).to(equal(U256.ZERO))
+                }
+
+                it("Get basic for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.knownAccount(backend.sender)).to(beNil())
+                    expect(childState.knownAccount(backend.sender)).to(beNil())
+
+                    parentState.touch(address: backend.sender)
+                    expect(parentState.knownAccount(backend.sender)?.basic.balance).to(equal(U256(from: 3003)))
+                    expect(childState.knownAccount(backend.sender)?.basic.balance).to(equal(U256(from: 3003)))
+
+                    expect(parentState.knownAccount(backend.address1)).to(beNil())
+                    expect(childState.knownAccount(backend.address1)).to(beNil())
+
+                    childState.touch(address: backend.address1)
+                    expect(parentState.knownAccount(backend.address1)).to(beNil())
+                    expect(childState.knownAccount(backend.address1)?.basic.balance).to(equal(U256.ZERO))
                 }
             }
 
             context("Storage Management") {
-                it("should handle storage resets correctly") {
+                let key1 = H256(from: U256(from: 10).toBigEndian)
+                let val1 = H256(from: [UInt8](repeating: 0xff, count: 32))
+                let expectedVal = H256(from: U256(from: 555).toBigEndian)
+
+                it("should handle storage and resets for current state") {
                     let backend = MockBackend()
                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
 
+                    expect(state.knownStorage(address: backend.sender, key: backend.storageKey1)).to(beNil())
+                    expect(state.knownStorage(address: backend.address1, key: key1)).to(beNil())
+
+                    expect(state.storage(address: backend.sender, index: backend.storageKey1)).to(equal(expectedVal))
+                    // Cashed value should be available in knownStorage after access
+                    expect(state.knownStorage(address: backend.sender, key: backend.storageKey1)).to(equal(expectedVal))
+
                     // Set value and then reset
-                    state.setStorage(address: addr1, key: key1, value: val1)
-                    expect(state.knownStorage(address: addr1, key: key1)).to(equal(val1))
+                    state.setStorage(address: backend.address1, key: key1, value: val1)
+                    expect(state.knownStorage(address: backend.address1, key: key1)).to(equal(val1))
+                    // Account was not cashed before at all
+                    expect(state.knownAccount(backend.address1)?.reset).to(beNil())
 
-                    state.resetStorage(address: addr1)
+                    // Account cashed
+                    state.resetStorage(address: backend.address1)
 
-                    expect(state.storages[addr1]).to(beNil())
-                    expect(state.accounts[addr1]?.reset).to(beTrue())
-                    expect(state.knownStorage(address: addr1, key: key1)).to(equal(H256.ZERO))
+                    expect(state.storages[backend.address1]).to(beNil())
+                    expect(state.storage(address: backend.sender, index: backend.storageKey1)).to(equal(expectedVal))
+                    expect(state.accounts[backend.address1]?.reset).to(beTrue())
+                    // Reset account should return zero valued
+                    expect(state.knownStorage(address: backend.address1, key: key1)).to(equal(H256.ZERO))
                 }
 
-                it("should return ZERO for storage if account is marked reset, even if parent has value") {
+                it("should handle storage and resets for substate") {
                     let backend = MockBackend()
                     let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                    parentState.setStorage(address: addr1, key: key1, value: val1)
-
                     let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
                     childState.parent = parentState
 
-                    _ = childState.getAccountAndTouch(addr1)
-                    childState.accounts[addr1]?.reset = true
+                    expect(parentState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(beNil())
+                    expect(childState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(beNil())
 
-                    expect(childState.knownStorage(address: addr1, key: key1)).to(equal(H256.ZERO))
+                    expect(parentState.storage(address: backend.sender, index: backend.storageKey1)).to(equal(expectedVal))
+                    // Cashed value in parent state
+                    expect(childState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(equal(expectedVal))
+
+                    // Set value and then reset
+                    parentState.setStorage(address: backend.sender, key: key1, value: val1)
+                    expect(parentState.knownStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.knownStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(parentState.knownAccount(backend.sender)?.reset).to(beNil())
+                    expect(childState.knownAccount(backend.sender)?.reset).to(beNil())
+
+                    let val2 = H256(from: [UInt8](repeating: 0xee, count: 32))
+
+                    childState.setStorage(address: backend.sender, key: backend.storageKey1, value: val2)
+                    expect(parentState.knownStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(equal(val2))
+                    expect(parentState.knownAccount(backend.sender)?.reset).to(beNil())
+                    expect(childState.knownAccount(backend.sender)?.reset).to(beNil())
+
+                    // Account cashed
+                    parentState.resetStorage(address: backend.sender)
+
+                    expect(parentState.storages[backend.sender]).to(beNil())
+                    expect(parentState.accounts[backend.sender]?.reset).to(beTrue())
+                    expect(parentState.knownStorage(address: backend.sender, key: key1)).to(equal(H256.ZERO))
+
+                    expect(childState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(equal(val2))
+                    expect(childState.accounts[backend.sender]?.reset).to(beNil())
+
+                    childState.resetStorage(address: backend.sender)
+
+                    expect(parentState.storages[backend.sender]).to(beNil())
+                    expect(parentState.accounts[backend.sender]?.reset).to(beTrue())
+                    expect(childState.storages[backend.sender]).to(beNil())
+                    expect(childState.accounts[backend.sender]?.reset).to(beTrue())
+
+                    expect(parentState.knownStorage(address: backend.sender, key: key1)).to(equal(H256.ZERO))
+                    expect(childState.knownStorage(address: backend.sender, key: backend.storageKey1)).to(equal(H256.ZERO))
                 }
             }
 
+            context("Track create and deleted accounts state") {
+                it("setDeleted, isDeleted") {
+                    let backend = MockBackend()
+                    let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    child.parent = parent
+
+                    // Case 1: Inherited from parent
+                    let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                    expect(parent.isDeleted(addr1)).to(beFalse())
+                    expect(child.isDeleted(addr1)).to(beFalse())
+
+                    parent.setDeleted(address: addr1)
+                    expect(parent.isDeleted(addr1)).to(beTrue())
+                    expect(child.isDeleted(addr1)).to(beTrue())
+
+                    // Case 2: Set in child
+                    let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+                    child.setDeleted(address: addr2)
+                    expect(parent.isDeleted(addr2)).to(beFalse())
+                    expect(child.isDeleted(addr2)).to(beTrue())
+
+                    // Case 3: Not deleted
+                    let addr3 = H160(from: [UInt8](repeating: 0x03, count: 20))
+                    expect(parent.isDeleted(addr3)).to(beFalse())
+                    expect(child.isDeleted(addr3)).to(beFalse())
+                }
+
+                it("setCreated, isCreated") {
+                    let backend = MockBackend()
+                    let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    child.parent = parent
+
+                    // Case 1: Inherited from parent
+                    let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                    expect(parent.isCreated(addr1)).to(beFalse())
+                    expect(child.isCreated(addr1)).to(beFalse())
+
+                    parent.setCreated(address: addr1)
+                    expect(parent.isCreated(addr1)).to(beTrue())
+                    expect(child.isCreated(addr1)).to(beTrue())
+
+                    // Case 2: Set in child
+                    let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+                    child.setCreated(address: addr2)
+                    expect(parent.isCreated(addr2)).to(beFalse())
+                    expect(child.isCreated(addr2)).to(beTrue())
+
+                    // Case 3: Not created
+                    let addr3 = H160(from: [UInt8](repeating: 0x03, count: 20))
+                    expect(parent.isCreated(addr3)).to(beFalse())
+                    expect(child.isCreated(addr3)).to(beFalse())
+                }
+            }
+
+            context("Environmental Data") {
+                it("gasPrice") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.gasPrice()).to(equal(U256(from: 333)))
+                }
+
+                it("origin") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.origin()).to(equal(backend.sender))
+                }
+
+                it("blockHash") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockHash(number: U256.ZERO)).to(equal(H256(from: U256(from: 100).toBigEndian)))
+                }
+
+                it("blockNumber") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockNumber()).to(equal(U256(from: 1000)))
+                }
+
+                it("blockCoinbase") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockCoinbase()).to(equal(backend.coinBase))
+                }
+
+                it("blockTimestamp") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockTimestamp()).to(equal(U256(from: 1234567890)))
+                }
+
+                it("blockDifficulty") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockDifficulty()).to(equal(U256(from: 999)))
+                }
+
+                it("blockRandomness") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockRandomness()).to(equal(H256(from: U256(from: 22).toBigEndian)))
+                }
+
+                it("blockGasLimit") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockGasLimit()).to(equal(U256(from: 8000000)))
+                }
+
+                it("blockBaseFeePerGas") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blockBaseFeePerGas()).to(equal(U256(from: 300)))
+                }
+
+                it("chainId") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.chainId()).to(equal(U256(from: 1)))
+                }
+
+                it("blobGasPrice") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.blobGasPrice()).to(equal(U128(from: 410)))
+                }
+
+                it("getBlobHash") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.getBlobHash(index: 0)).to(equal(U256(from: 601)))
+                }
+
+                it("exists") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.exists(address: backend.sender)).to(beFalse())
+
+                    _ = state.getAccountAndTouch(backend.sender)
+                    expect(state.exists(address: backend.sender)).to(beTrue())
+                }
+            }
+
+            context("Handle transfers") {
+                it("Transfer with OutOfFund and self transfer") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.address1).balance).to(equal(U256.ZERO))
+
+                    let transfer1 = Transfer(source: backend.address1, target: backend.sender, value: U256(from: 50))
+                    let res1 = state.transfer(transfer: transfer1)
+                    expect(res1).to(beFailure { error in expect(error).to(equal(.OutOfFund)) })
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.address1).balance).to(equal(U256.ZERO))
+
+                    let transfer2 = Transfer(source: backend.sender, target: backend.sender, value: U256(from: 50))
+                    let res2 = state.transfer(transfer: transfer2)
+                    expect(res2).to(beSuccess())
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                }
+
+                it("Successful transfer") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 3003)))
+                    expect(state.basic(address: backend.address1).balance).to(equal(U256.ZERO))
+
+                    let transfer1 = Transfer(source: backend.sender, target: backend.address1, value: U256(from: 50))
+                    let res = state.transfer(transfer: transfer1)
+                    expect(res).to(beSuccess())
+                    expect(state.basic(address: backend.sender).balance).to(equal(U256(from: 2953)))
+                    expect(state.basic(address: backend.address1).balance).to(equal(U256(from: 50)))
+                }
+            }
+
+            context("isEmpty logic") {
+                let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+
+                it("should identify empty accounts correctly") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+
+                    // Account with balance is not empty
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 1), nonce: .ZERO), code: nil, reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beFalse())
+
+                    // Account with no balance, no nonce, and empty code is empty
+                    state.accounts[addr2] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [], reset: false)
+                    expect(state.isEmpty(address: addr2)).to(beTrue())
+                }
+
+                it("should determine if account is empty correctly") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+
+                    // 1. Locally known: Has Balance
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 1), nonce: .ZERO), code: [], reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beFalse())
+
+                    // 2. Locally known: Has Nonce
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: U256(from: 1)), code: [], reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beFalse())
+
+                    // 3. Locally known: Has Code
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [0x00], reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beFalse())
+
+                    // 4. Locally known: Empty
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [], reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beTrue())
+
+                    // 5. Locally known: Empty with code nil
+                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: nil, reset: false)
+                    expect(state.isEmpty(address: addr1)).to(beTrue())
+
+                    // Not cashed
+                    expect(state.isEmpty(address: backend.sender)).to(beFalse())
+                    expect(state.isEmpty(address: addr2)).to(beTrue())
+                }
+            }
+
+            // TODO:
             context("Cold/Warm Access (EIP-2929)") {
+                let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+
                 it("should correctly identify cold vs warm addresses") {
                     let backend = MockBackend()
                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
@@ -196,6 +730,9 @@ final class MemoryStateSpec: QuickSpec {
             }
 
             context("State Transitions (Enter/Exit)") {
+                let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+
                 it("should swap state correctly on enter") {
                     let backend = MockBackend()
                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
@@ -224,89 +761,8 @@ final class MemoryStateSpec: QuickSpec {
                 }
             }
 
-            context("Nonce and Balance Mutations") {
-                it("should increment nonce and handle overflow") {
-                    let backend = MockBackend()
-                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                    // Normal increment
-                    _ = state.incNonce(address: addr1)
-                    expect(state.knownAccount(addr1)?.basic.nonce).to(equal(U256(from: 21)))
-
-                    // Mock max nonce
-                    state.accounts[addr1]?.basic.nonce = U256(from: UInt64.max)
-                    let result = state.incNonce(address: addr1)
-
-                    expect(result).to(beFailure())
-                }
-            }
-
-            context("isEmpty logic") {
-                it("should identify empty accounts correctly") {
-                    let backend = MockBackend()
-                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                    // Account with balance is not empty
-                    state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 1), nonce: .ZERO), code: nil, reset: false)
-                    expect(state.isEmpty(address: addr1)).to(beFalse())
-
-                    // Account with no balance, no nonce, and empty code is empty
-                    state.accounts[addr2] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [], reset: false)
-                    expect(state.isEmpty(address: addr2)).to(beTrue())
-                }
-            }
-
-            context("Account code state") {
-                it("should handle code management (setCode, knownCode)") {
-                    let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
-                    let backend = MockBackend()
-                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                    // Case: Unknown code (should be nil in local state logic, though knownAccount usually handles lookup)
-                    // Note: knownCode uses knownAccount internally. If not in state/parent, returns nil.
-                    // But our MockBackend returns code.
-                    // Let's verify setCode overrides backend.
-
-                    let newCode: [UInt8] = [0xfe, 0xfe]
-                    state.setCode(address: addr1, code: newCode)
-
-                    expect(state.knownCode(addr1)).to(equal(newCode))
-
-                    // Verify it touched the account
-                    expect(state.accounts[addr1]).toNot(beNil())
-                    expect(state.accounts[addr1]?.code).to(equal(newCode))
-                }
-            }
             /*
              context("Account code state") {
-                 let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
-                 let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
-                 let key1 = H256.ZERO
-                 let val1 = H256(from: [UInt8](repeating: 0xff, count: 32))
-
-                 it("should handle storage lookups recursively (knownStorage)") {
-                     let backend = MockBackend()
-                     let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // Setup parent storage
-                     parent.setStorage(address: addr1, key: key1, value: val1)
-
-                     let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
-                     child.parent = parent
-
-                     // Case 1: Fetch from parent
-                     expect(child.knownStorage(address: addr1, key: key1)).to(equal(val1))
-
-                     // Case 2: Value in current state
-                     let newVal = H256(from: [0xaa])
-                     child.setStorage(address: addr1, key: key1, value: newVal)
-                     expect(child.knownStorage(address: addr1, key: key1)).to(equal(newVal))
-
-                     // Case 3: Account reset in current state (should return ZERO even if parent has value)
-                     child.resetStorage(address: addr1)
-                     expect(child.knownStorage(address: addr1, key: key1)).to(equal(H256.ZERO))
-                 }
-
                  it("should handle original storage lookups (knownOriginalStorage)") {
                      let backend = MockBackend()
                      let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
@@ -329,160 +785,6 @@ final class MemoryStateSpec: QuickSpec {
                      // If we call freshState.knownOriginalStorage directly:
                      // It returns parent?.knownOriginalStorage. If parent is nil, it returns nil.
                      expect(freshState.knownOriginalStorage(addr1)).to(beNil())
-                 }
-
-                 it("should track deleted accounts (setDeleted, isDeleted)") {
-                     let backend = MockBackend()
-                     let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                     parent.setDeleted(address: addr1)
-
-                     let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
-                     child.parent = parent
-
-                     // Case 1: Inherited from parent
-                     expect(child.isDeleted(addr1)).to(beTrue())
-
-                     // Case 2: Set in child
-                     child.setDeleted(address: addr2)
-                     expect(child.isDeleted(addr2)).to(beTrue())
-
-                     // Case 3: Not deleted
-                     let addr3 = H160(from: [0x03])
-                     expect(child.isDeleted(addr3)).to(beFalse())
-                 }
-
-                 it("should track created accounts (setCreated, isCreated)") {
-                     let backend = MockBackend()
-                     let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                     parent.setCreated(address: addr1)
-
-                     let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
-                     child.parent = parent
-
-                     // Case 1: Inherited from parent
-                     expect(child.isCreated(addr1)).to(beTrue())
-
-                     // Case 2: Set in child
-                     child.setCreated(address: addr2)
-                     expect(child.isCreated(addr2)).to(beTrue())
-
-                     // Case 3: Not created
-                     let addr3 = H160(from: [0x03])
-                     expect(child.isCreated(addr3)).to(beFalse())
-                 }
-
-                 it("should handle balance operations (deposit, withdraw, resetBalance)") {
-                     let backend = MockBackend()
-                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // Deposit
-                     state.deposit(address: addr1, value: U256(from: 100))
-                     expect(state.knownBasic(addr1)?.balance).to(equal(U256(from: 110))) // 10 (mock) + 100
-
-                     // Withdraw Success
-                     let res = state.withdraw(address: addr1, value: U256(from: 50))
-                     expect(res).to(beSuccess())
-                     expect(state.knownBasic(addr1)?.balance).to(equal(U256(from: 60)))
-
-                     // Withdraw Fail (Out of Fund)
-                     let resFail = state.withdraw(address: addr1, value: U256(from: 1000))
-                     expect(resFail).to(beFailure { error in
-                         expect(error).to(equal(.OutOfFund))
-                     })
-
-                     // Reset Balance
-                     state.resetBalance(address: addr1)
-                     expect(state.knownBasic(addr1)?.balance).to(equal(U256.ZERO))
-                 }
-
-                 it("should handle transfers") {
-                     let backend = MockBackend()
-                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // Initial setup
-                     state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 100), nonce: .ZERO), code: nil, reset: false)
-                     state.accounts[addr2] = StateAccount(basic: BasicAccount(balance: U256(from: 0), nonce: .ZERO), code: nil, reset: false)
-
-                     // Case 1: Transfer to self (should succeed and do nothing)
-                     let transferSelf = Transfer(source: addr1, target: addr1, value: U256(from: 50))
-                     let resSelf = state.transfer(transfer: transferSelf)
-                     expect(resSelf).to(beSuccess())
-                     expect(state.knownBasic(addr1)?.balance).to(equal(U256(from: 100)))
-
-                     // Case 2: Out of funds
-                     let transferOOF = Transfer(source: addr1, target: addr2, value: U256(from: 200))
-                     let resOOF = state.transfer(transfer: transferOOF)
-                     expect(resOOF).to(beFailure { error in expect(error).to(equal(.OutOfFund)) })
-
-                     // Case 3: Successful transfer
-                     let transferOk = Transfer(source: addr1, target: addr2, value: U256(from: 40))
-                     let resOk = state.transfer(transfer: transferOk)
-                     expect(resOk).to(beSuccess())
-                     expect(state.knownBasic(addr1)?.balance).to(equal(U256(from: 60)))
-                     expect(state.knownBasic(addr2)?.balance).to(equal(U256(from: 40)))
-                 }
-
-                 it("should touch accounts explicitly") {
-                     let backend = MockBackend()
-                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     expect(state.accounts[addr1]).to(beNil())
-                     state.touch(address: addr1)
-                     expect(state.accounts[addr1]).toNot(beNil())
-                 }
-
-                 it("should retrieve environmental data (gasPrice)") {
-                     let backend = MockBackend()
-                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                     // MockBackend gasPrice returns ZERO
-                     expect(state.gasPrice()).to(equal(U256.ZERO))
-                 }
-
-                 it("should determine if account is empty correctly") {
-                     let backend = MockBackend()
-                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // 1. Locally known: Has Balance
-                     state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 1), nonce: .ZERO), code: [], reset: false)
-                     expect(state.isEmpty(address: addr1)).to(beFalse())
-
-                     // 2. Locally known: Has Nonce
-                     state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: U256(from: 1)), code: [], reset: false)
-                     expect(state.isEmpty(address: addr1)).to(beFalse())
-
-                     // 3. Locally known: Has Code
-                     state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [0x00], reset: false)
-                     expect(state.isEmpty(address: addr1)).to(beFalse())
-
-                     // 4. Locally known: Empty
-                     state.accounts[addr1] = StateAccount(basic: BasicAccount(balance: .ZERO, nonce: .ZERO), code: [], reset: false)
-                     expect(state.isEmpty(address: addr1)).to(beTrue())
-
-                     // 5. Unknown locally: Fetch from backend
-                     // MockBackend returns default account with balance 10 -> Not Empty
-                     expect(state.isEmpty(address: addr2)).to(beFalse())
-                 }
-
-                 it("should handle getAccountAndTouch edge cases") {
-                     let backend = MockBackend()
-                     let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // Case: Parent has account
-                     parent.accounts[addr1] = StateAccount(basic: BasicAccount(balance: U256(from: 99), nonce: .ZERO), code: [], reset: true)
-
-                     let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
-                     child.parent = parent
-
-                     // Trigger fetch from parent
-                     let acc = child.getAccountAndTouch(addr1)
-
-                     // Should be cloned
-                     expect(acc.basic.balance).to(equal(U256(from: 99)))
-                     // Should NOT trigger reset in child copy immediately, but reset flag logic in getAccountAndTouch sets `reset: false` for the new copy
-                     expect(acc.reset).to(beFalse())
-
-                     // Check local cache is populated
-                     expect(child.accounts[addr1]).toNot(beNil())
                  }
              }
              */

--- a/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
+++ b/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
@@ -93,11 +93,17 @@ final class MockBackend: Backend {
     }
 
     func isEmptyStorage(address: H160) -> Bool {
-        storages[address]?.isEmpty ?? true
+        if address == sender {
+            return false
+        }
+        return storages[address]?.isEmpty ?? true
     }
 
     func originalStorage(address: H160, index: H256) -> H256? {
-        storages[address]?[index]
+        if address == sender, index == storageKey1 {
+            return H256(from: U256(from: 555).toBigEndian)
+        }
+        return storages[address]?[index]
     }
 }
 
@@ -616,19 +622,16 @@ final class MemoryStateSpec: QuickSpec {
                 it("isEmptyStorage") {
                     let backend = MockBackend()
                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                    expect(state.isEmptyStorage(address: backend.sender)).to(beTrue())
-
-                    state.setStorage(address: backend.sender, key: backend.storageKey1, value: H256(from: U256(from: 555).toBigEndian))
-                    expect(state.storage(address: backend.sender, index: backend.storageKey1)).to(equal(H256(from: U256(from: 555).toBigEndian)))
+                    expect(state.isEmptyStorage(address: backend.address1)).to(beTrue())
                     expect(state.isEmptyStorage(address: backend.sender)).to(beFalse())
                 }
 
                 it("originalStorage") {
                     let backend = MockBackend()
                     let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                    expect(state.originalStorage(address: backend.sender, index: backend.storageKey1)).to(beNil())
+                    expect(state.originalStorage(address: backend.sender, index: backend.storageKey1)).to(equal(H256(from: U256(from: 555).toBigEndian)))
+                    expect(state.originalStorage(address: backend.address1, index: backend.storageKey1)).to(beNil())
                 }
-
             }
 
             context("Handle transfers") {
@@ -757,6 +760,87 @@ final class MemoryStateSpec: QuickSpec {
                 }
             }
 
+            context("Authorization list") {
+                let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
+                let addr2 = H160(from: [UInt8](repeating: 0x02, count: 20))
+
+                it("getAuthorityTargetRecursive with substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.getAuthorityTargetRecursive(authority: addr1)).to(beNil())
+                    expect(childState.getAuthorityTargetRecursive(authority: addr1)).to(beNil())
+                    expect(parentState.getAuthorityTargetRecursive(authority: addr2)).to(beNil())
+                    expect(childState.getAuthorityTargetRecursive(authority: addr2)).to(beNil())
+
+                    parentState.metadata.addAuthority(authority: addr1, address: addr2)
+                    childState.metadata.addAuthority(authority: addr2, address: addr1)
+
+                    expect(parentState.getAuthorityTargetRecursive(authority: addr1)).to(equal(addr2))
+                    expect(childState.getAuthorityTargetRecursive(authority: addr1)).to(equal(addr2))
+                    expect(parentState.getAuthorityTargetRecursive(authority: addr2)).to(beNil())
+                    expect(childState.getAuthorityTargetRecursive(authority: addr2)).to(equal(addr1))
+
+                    expect(parentState.getAuthorityTarget(authority: addr1)).to(equal(addr2))
+                    expect(childState.getAuthorityTarget(authority: addr1)).to(equal(addr2))
+                    expect(parentState.getAuthorityTarget(authority: addr2)).to(beNil())
+                    expect(childState.getAuthorityTarget(authority: addr2)).to(equal(addr1))
+                }
+
+                it("getAuthorityTarget with substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.getAuthorityTarget(authority: addr1)).to(beNil())
+                    expect(parentState.getAuthorityTarget(authority: addr2)).to(beNil())
+
+                    var code: [UInt8] = [0xef, 0x01, 0x00]
+                    code.append(contentsOf: addr2.BYTES)
+                    parentState.setCode(address: addr1, code: code)
+
+                    var code2: [UInt8] = [0xef, 0x01, 0x00]
+                    code2.append(contentsOf: addr1.BYTES)
+                    childState.setCode(address: addr2, code: code2)
+
+                    // After delegation address detected - set authority, also available for child
+                    expect(parentState.getAuthorityTarget(authority: addr1)).to(equal(addr2))
+                    expect(childState.getAuthorityTarget(authority: addr1)).to(equal(addr2))
+
+                    expect(parentState.getAuthorityTarget(authority: addr2)).to(beNil())
+                    expect(childState.getAuthorityTarget(authority: addr2)).to(equal(addr1))
+                }
+
+                it("getAuthorityTarget with substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.isAuthorityCold(address: addr1)).to(beNil())
+                    expect(childState.isAuthorityCold(address: addr1)).to(beNil())
+                    parentState.metadata.accessed?.setAccessAddress(addr2)
+                    expect(parentState.isAuthorityCold(address: addr1)).to(beNil())
+
+                    parentState.metadata.addAuthority(authority: addr1, address: addr2)
+                    expect(parentState.isAuthorityCold(address: addr1)).to(beFalse())
+                    expect(childState.isAuthorityCold(address: addr1)).to(beFalse())
+
+                    expect(parentState.isAuthorityCold(address: addr2)).to(beNil())
+                    expect(childState.isAuthorityCold(address: addr2)).to(beNil())
+
+                    childState.metadata.addAuthority(authority: addr2, address: addr1)
+                    expect(parentState.isAuthorityCold(address: addr2)).to(beNil())
+                    expect(childState.isAuthorityCold(address: addr2)).to(beTrue())
+
+                    childState.metadata.accessed?.setAccessAddress(addr1)
+                    expect(childState.isAuthorityCold(address: addr1)).to(beFalse())
+                }
+            }
+
             // TODO:
             context("Cold/Warm Access (EIP-2929)") {
                 let addr1 = H160(from: [UInt8](repeating: 0x01, count: 20))
@@ -821,34 +905,6 @@ final class MemoryStateSpec: QuickSpec {
                     expect(state.isCreated(addr2)).to(beTrue())
                 }
             }
-
-            /*
-             context("Account code state") {
-                 it("should handle original storage lookups (knownOriginalStorage)") {
-                     let backend = MockBackend()
-                     let parent = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-
-                     // Mock backend storage access via parent
-                     // We need to inject into backend or parent to test the fallback
-                     // MemoryState.knownOriginalStorage falls back to parent.knownOriginalStorage
-
-                     let child = MemoryState(metadata: parent.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
-                     child.parent = parent
-
-                     // Case 1: Account reset in child -> returns ZERO
-                     child.resetStorage(address: addr1)
-                     expect(child.knownOriginalStorage(addr1)).to(equal(H256.ZERO))
-
-                     // Case 2: Normal lookup (mocks backend interaction via recursion)
-                     // Since MockBackend.originalStorage returns value, and we didn't reset in a fresh state:
-                     let freshState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
-                     // The MemoryState wrapper implementation of Backend calls knownOriginalStorage.
-                     // If we call freshState.knownOriginalStorage directly:
-                     // It returns parent?.knownOriginalStorage. If parent is nil, it returns nil.
-                     expect(freshState.knownOriginalStorage(addr1)).to(beNil())
-                 }
-             }
-             */
         }
     }
 }

--- a/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
+++ b/Tests/InterpreterTests/MemoryState/MemoryStateTests.swift
@@ -612,6 +612,23 @@ final class MemoryStateSpec: QuickSpec {
                     _ = state.getAccountAndTouch(backend.sender)
                     expect(state.exists(address: backend.sender)).to(beTrue())
                 }
+
+                it("isEmptyStorage") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.isEmptyStorage(address: backend.sender)).to(beTrue())
+
+                    state.setStorage(address: backend.sender, key: backend.storageKey1, value: H256(from: U256(from: 555).toBigEndian))
+                    expect(state.storage(address: backend.sender, index: backend.storageKey1)).to(equal(H256(from: U256(from: 555).toBigEndian)))
+                    expect(state.isEmptyStorage(address: backend.sender)).to(beFalse())
+                }
+
+                it("originalStorage") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    expect(state.originalStorage(address: backend.sender, index: backend.storageKey1)).to(beNil())
+                }
+
             }
 
             context("Handle transfers") {
@@ -693,6 +710,50 @@ final class MemoryStateSpec: QuickSpec {
                     // Not cashed
                     expect(state.isEmpty(address: backend.sender)).to(beFalse())
                     expect(state.isEmpty(address: addr2)).to(beTrue())
+                }
+            }
+
+            context("TStorage Management") {
+                let key1 = H256(from: U256(from: 10).toBigEndian)
+                let val1 = H256(from: [UInt8](repeating: 0xf2, count: 32))
+                let expectedVal = H256(from: U256(from: 555).toBigEndian)
+
+                it("should handle tstorage for current state") {
+                    let backend = MockBackend()
+                    let state = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+
+                    expect(state.knownTStorage(address: backend.address1, key: key1)).to(beNil())
+                    expect(state.getTStorage(address: backend.address1, key: key1)).to(equal(H256.ZERO))
+
+                    state.setTStorage(address: backend.address1, key: key1, value: val1)
+                    expect(state.knownTStorage(address: backend.address1, key: key1)).to(equal(val1))
+                    expect(state.getTStorage(address: backend.address1, key: key1)).to(equal(val1))
+                }
+
+                it("should handle tstorage for substate") {
+                    let backend = MockBackend()
+                    let parentState = MemoryState(gasLimit: 10000, backend: backend, hardFork: .Berlin)
+                    let childState = MemoryState(metadata: parentState.metadata.spitChild(gasLimit: 5000, isStatic: false), backend: backend)
+                    childState.parent = parentState
+
+                    expect(parentState.knownTStorage(address: backend.sender, key: backend.storageKey1)).to(beNil())
+                    expect(childState.knownTStorage(address: backend.sender, key: backend.storageKey1)).to(beNil())
+                    expect(parentState.getTStorage(address: backend.sender, key: key1)).to(equal(H256.ZERO))
+                    expect(childState.getTStorage(address: backend.sender, key: key1)).to(equal(H256.ZERO))
+
+                    parentState.setTStorage(address: backend.sender, key: key1, value: val1)
+                    expect(parentState.knownTStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.knownTStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(parentState.getTStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.getTStorage(address: backend.sender, key: key1)).to(equal(val1))
+
+                    let val2 = H256(from: [UInt8](repeating: 0xee, count: 32))
+
+                    childState.setTStorage(address: backend.sender, key: key1, value: val2)
+                    expect(parentState.knownTStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.knownTStorage(address: backend.sender, key: key1)).to(equal(val2))
+                    expect(parentState.getTStorage(address: backend.sender, key: key1)).to(equal(val1))
+                    expect(childState.getTStorage(address: backend.sender, key: key1)).to(equal(val2))
                 }
             }
 

--- a/Tests/InterpreterTests/MemoryState/MetadataTests.swift
+++ b/Tests/InterpreterTests/MemoryState/MetadataTests.swift
@@ -93,7 +93,7 @@ final class MemoryStateMetadataSpec: QuickSpec {
                 }
             }
 
-            context("Access List Management") {
+            context("Access dataw Management") {
                 it("manages authority (EIP-7702)") {
                     var metadata = MemoryState.Metadata(gasometer: Gas(limit: 1000), hardFork: .Berlin)
                     metadata.addAuthority(authority: addr1, address: addr2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: nimble (13.7.1 → 13.8.0), swift-algorithms (1.2.0 → 1.2.1), swift-argument-parser (1.5.0 → 1.7.0), swift-numerics (1.0.2 → 1.1.1).

* **Refactor**
  * Memory state caching and access paths reworked; several previously exposed helper lookups removed.
  * Authorization's default instance changed to an immutable stored constant.

* **Tests**
  * Expanded and hardened tests with deterministic backend values and broader state scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->